### PR TITLE
Introduce a protocol for the requests

### DIFF
--- a/templates/api.hbs
+++ b/templates/api.hbs
@@ -39,3 +39,9 @@ open class {{name}}Api {
     {{>frag/operation group=..}}
 {{/each}}
 }
+
+{{#each operations}}
+{{#if (gt (count parameters) 1)}}
+{{>frag/parametersProtocol group=..}}
+{{/if}}
+{{/each}}

--- a/templates/frag/operation.hbs
+++ b/templates/frag/operation.hbs
@@ -56,7 +56,7 @@ open func {{{name}}}(_ __request: {{{className (concat group.name '_' name '_' '
 {{#if deprecated}}
 @available(*, deprecated)
 {{/if}}
-open func {{{name}}}(_ __request: {{group.name}}{{{className (concat name '_' 'requestable')}}}{{#if requestBody.nativeType}}, {{{requestBody.name}}}: {{{requestBody.nativeType}}}{{#unless requestBody.required}} = nil{{/unless}}{{/if}}) async throws -> {{className name}}Result {
+open func {{{name}}}(_ __request: {{{className (concat group.name '_' name '_' 'requestable')}}}{{#if requestBody.nativeType}}, {{{requestBody.name}}}: {{{requestBody.nativeType}}}{{#unless requestBody.required}} = nil{{/unless}}{{/if}}) async throws -> {{className name}}Result {
     return try await {{{name}}}({{{_requestCallParams}}})
 }
 

--- a/templates/frag/operation.hbs
+++ b/templates/frag/operation.hbs
@@ -49,7 +49,7 @@ public enum {{className name}}Result {
 @available(*, deprecated)
 {{/if}}
 open func {{{name}}}(_ __request: {{group.name}}{{{className (concat name '_' 'requestable')}}}, {{#if requestBody.nativeType}}{{{requestBody.name}}}: {{{requestBody.nativeType}}}{{#unless requestBody.required}} = nil{{/unless}}, {{/if}}responseQueue: DispatchQueue? = nil, completion: @escaping ((_ result: Result<{{className name}}Result, Error>) -> Void)) {
-    {{{name}}}({{{_requestCallParams}}}{{#if requestBody.nativeType}}, {{{requestBody.name}}}: {{{requestBody.name}}}{{/if}}, responseQueue: responseQueue, completion: completion)
+    {{{name}}}({{{_requestCallParams}}}, responseQueue: responseQueue, completion: completion)
 }
 
 {{>frag/operationDocumentation}}
@@ -57,7 +57,7 @@ open func {{{name}}}(_ __request: {{group.name}}{{{className (concat name '_' 'r
 @available(*, deprecated)
 {{/if}}
 open func {{{name}}}(_ __request: {{group.name}}{{{className (concat name '_' 'requestable')}}}{{#if requestBody.nativeType}}, {{{requestBody.name}}}: {{{requestBody.nativeType}}}{{#unless requestBody.required}} = nil{{/unless}}{{/if}}) async throws -> {{className name}}Result {
-    return try await {{{name}}}({{{_requestCallParams}}}{{#if requestBody.nativeType}}, {{{requestBody.name}}}: {{{requestBody.name}}}{{/if}})
+    return try await {{{name}}}({{{_requestCallParams}}})
 }
 
 {{/if}}

--- a/templates/frag/operation.hbs
+++ b/templates/frag/operation.hbs
@@ -48,7 +48,7 @@ public enum {{className name}}Result {
 {{#if deprecated}}
 @available(*, deprecated)
 {{/if}}
-open func {{{name}}}(_ __request: {{{className (concat name '_' 'request')}}}, {{#if requestBody.nativeType}}{{{requestBody.name}}}: {{{requestBody.nativeType}}}{{#unless requestBody.required}} = nil{{/unless}}, {{/if}}responseQueue: DispatchQueue? = nil, completion: @escaping ((_ result: Result<{{className name}}Result, Error>) -> Void)) {
+open func {{{name}}}(_ __request: {{group.name}}{{{className (concat name '_' 'request')}}}, {{#if requestBody.nativeType}}{{{requestBody.name}}}: {{{requestBody.nativeType}}}{{#unless requestBody.required}} = nil{{/unless}}, {{/if}}responseQueue: DispatchQueue? = nil, completion: @escaping ((_ result: Result<{{className name}}Result, Error>) -> Void)) {
     {{{name}}}({{{_requestCallParams}}}{{#if requestBody.nativeType}}, {{{requestBody.name}}}: {{{requestBody.name}}}{{/if}}, responseQueue: responseQueue, completion: completion)
 }
 
@@ -56,7 +56,7 @@ open func {{{name}}}(_ __request: {{{className (concat name '_' 'request')}}}, {
 {{#if deprecated}}
 @available(*, deprecated)
 {{/if}}
-open func {{{name}}}(_ __request: {{{className (concat name '_' 'request')}}}{{#if requestBody.nativeType}}, {{{requestBody.name}}}: {{{requestBody.nativeType}}}{{#unless requestBody.required}} = nil{{/unless}}{{/if}}) async throws -> {{className name}}Result {
+open func {{{name}}}(_ __request: {{group.name}}{{{className (concat name '_' 'request')}}}{{#if requestBody.nativeType}}, {{{requestBody.name}}}: {{{requestBody.nativeType}}}{{#unless requestBody.required}} = nil{{/unless}}{{/if}}) async throws -> {{className name}}Result {
     return try await {{{name}}}({{{_requestCallParams}}}{{#if requestBody.nativeType}}, {{{requestBody.name}}}: {{{requestBody.name}}}{{/if}})
 }
 

--- a/templates/frag/operation.hbs
+++ b/templates/frag/operation.hbs
@@ -48,7 +48,7 @@ public enum {{className name}}Result {
 {{#if deprecated}}
 @available(*, deprecated)
 {{/if}}
-open func {{{name}}}(_ __request: {{group.name}}{{{className (concat name '_' 'requestable')}}}, {{#if requestBody.nativeType}}{{{requestBody.name}}}: {{{requestBody.nativeType}}}{{#unless requestBody.required}} = nil{{/unless}}, {{/if}}responseQueue: DispatchQueue? = nil, completion: @escaping ((_ result: Result<{{className name}}Result, Error>) -> Void)) {
+open func {{{name}}}(_ __request: {{{className (concat group.name '_' name '_' 'requestable')}}}, {{#if requestBody.nativeType}}{{{requestBody.name}}}: {{{requestBody.nativeType}}}{{#unless requestBody.required}} = nil{{/unless}}, {{/if}}responseQueue: DispatchQueue? = nil, completion: @escaping ((_ result: Result<{{className name}}Result, Error>) -> Void)) {
     {{{name}}}({{{_requestCallParams}}}, responseQueue: responseQueue, completion: completion)
 }
 

--- a/templates/frag/operation.hbs
+++ b/templates/frag/operation.hbs
@@ -48,7 +48,7 @@ public enum {{className name}}Result {
 {{#if deprecated}}
 @available(*, deprecated)
 {{/if}}
-open func {{{name}}}(_ __request: {{group.name}}{{{className (concat name '_' 'request')}}}, {{#if requestBody.nativeType}}{{{requestBody.name}}}: {{{requestBody.nativeType}}}{{#unless requestBody.required}} = nil{{/unless}}, {{/if}}responseQueue: DispatchQueue? = nil, completion: @escaping ((_ result: Result<{{className name}}Result, Error>) -> Void)) {
+open func {{{name}}}(_ __request: {{group.name}}{{{className (concat name '_' 'requestable')}}}, {{#if requestBody.nativeType}}{{{requestBody.name}}}: {{{requestBody.nativeType}}}{{#unless requestBody.required}} = nil{{/unless}}, {{/if}}responseQueue: DispatchQueue? = nil, completion: @escaping ((_ result: Result<{{className name}}Result, Error>) -> Void)) {
     {{{name}}}({{{_requestCallParams}}}{{#if requestBody.nativeType}}, {{{requestBody.name}}}: {{{requestBody.name}}}{{/if}}, responseQueue: responseQueue, completion: completion)
 }
 
@@ -56,7 +56,7 @@ open func {{{name}}}(_ __request: {{group.name}}{{{className (concat name '_' 'r
 {{#if deprecated}}
 @available(*, deprecated)
 {{/if}}
-open func {{{name}}}(_ __request: {{group.name}}{{{className (concat name '_' 'request')}}}{{#if requestBody.nativeType}}, {{{requestBody.name}}}: {{{requestBody.nativeType}}}{{#unless requestBody.required}} = nil{{/unless}}{{/if}}) async throws -> {{className name}}Result {
+open func {{{name}}}(_ __request: {{group.name}}{{{className (concat name '_' 'requestable')}}}{{#if requestBody.nativeType}}, {{{requestBody.name}}}: {{{requestBody.nativeType}}}{{#unless requestBody.required}} = nil{{/unless}}{{/if}}) async throws -> {{className name}}Result {
     return try await {{{name}}}({{{_requestCallParams}}}{{#if requestBody.nativeType}}, {{{requestBody.name}}}: {{{requestBody.name}}}{{/if}})
 }
 

--- a/templates/frag/parametersProtocol.hbs
+++ b/templates/frag/parametersProtocol.hbs
@@ -1,0 +1,6 @@
+public protocol {{group.name}}{{{className (concat name '_' 'requestable')}}} {
+{{#each parameters}}
+    {{>frag/propertyDocumentation}}
+    var {{{name}}}: {{{nativeType}}} { get set }
+{{/each}}
+}

--- a/templates/frag/parametersStruct.hbs
+++ b/templates/frag/parametersStruct.hbs
@@ -1,4 +1,4 @@
-public struct {{{className (concat name '_' 'request')}}}: Swift.Equatable, Swift.Hashable {
+public struct {{{className (concat name '_' 'request')}}}: {{group.name}}{{{className (concat name '_' 'requestable')}}}, Swift.Equatable, Swift.Hashable {
 {{#each parameters}}
     {{>frag/propertyDocumentation}}
     public var {{{name}}}: {{{nativeType}}}

--- a/templates/frag/parametersStruct.hbs
+++ b/templates/frag/parametersStruct.hbs
@@ -1,4 +1,4 @@
-public struct {{{className (concat name '_' 'request')}}}: {{group.name}}{{{className (concat name '_' 'requestable')}}}, Swift.Equatable, Swift.Hashable {
+public struct {{{className (concat name '_' 'request')}}}: {{{className (concat group.name '_' name '_' 'requestable')}}}, Swift.Equatable, Swift.Hashable {
 {{#each parameters}}
     {{>frag/propertyDocumentation}}
     public var {{{name}}}: {{{nativeType}}}


### PR DESCRIPTION
Using our generated request struct becomes optional. We still generate our request structs because it’s convenient.

The benefit of using a protocol is that it allows consumers to make use of repeating patterns in an API by creating their own request objects that implement multiple `Requestable` protocols