### PR TITLE
Fixes request authorization to include a reauthentication attempt if authorize fails

### DIFF
--- a/.changeset/soft-lobsters-explode.md
+++ b/.changeset/soft-lobsters-explode.md
@@ -1,0 +1,5 @@
+---
+"@openapi-generator-plus/swift-client-generator": patch
+---
+
+Fixes request authorization to include a reauthentication attempt if authorize fails

--- a/templates/frag/requestSecurity.hbs
+++ b/templates/frag/requestSecurity.hbs
@@ -8,7 +8,12 @@ if !didAuthenticate {
     do {
         {{#each schemes}}
         if let securityClient = self.configuration.securityClient {
-            try await securityClient.authorize(request: &authedRequest, securityScheme: .{{{identifier scheme.name}}}, scopes: [{{#each scopes}}{{{stringLiteral name}}}{{#unless @last}}, {{/unless}}{{/each}}])
+            do {
+                try await securityClient.authorize(request: &authedRequest, securityScheme: .{{{identifier scheme.name}}}, scopes: [{{#each scopes}}{{{stringLiteral name}}}{{#unless @last}}, {{/unless}}{{/each}}])
+            } catch APIError.notAuthenticated {
+                try await securityClient.reauthenticate(failedRequest: authedRequest, securityScheme: .{{{identifier scheme.name}}}, scopes: [{{#each scopes}}{{{stringLiteral name}}}{{#unless @last}}, {{/unless}}{{/each}}])
+                try await securityClient.authorize(request: &authedRequest, securityScheme: .{{{identifier scheme.name}}}, scopes: [{{#each scopes}}{{{stringLiteral name}}}{{#unless @last}}, {{/unless}}{{/each}}])
+            }
         }
         {{/each}}
         didAuthenticate = true


### PR DESCRIPTION
When authorising a request, the security client might throw saying that it is not yet authenticated. We were effectively re-throwing that error rather than first attempting to reauthenticate. Certain clients such as the client credentials flow can always attempt to reauthenticate. In addition, performing this reauthentication here allows for an authentication with the appropriate scopes for the request.

Should it not be possible to reauthenticate, then the correct error will be rethrown as expected.