### PR TITLE
Fix: Resolve race condition issues in the oauth token manager

### DIFF
--- a/.changeset/hungry-jokes-brush.md
+++ b/.changeset/hungry-jokes-brush.md
@@ -1,0 +1,5 @@
+---
+"@openapi-generator-plus/swift-client-generator": patch
+---
+
+Clear token on 401 refresh response

--- a/.changeset/light-mayflies-guess.md
+++ b/.changeset/light-mayflies-guess.md
@@ -1,0 +1,5 @@
+---
+"@openapi-generator-plus/swift-client-generator": patch
+---
+
+Oauth Credentials Flow: prevent multiple simultaneous attempts to reauthenticate

--- a/.changeset/witty-maps-try.md
+++ b/.changeset/witty-maps-try.md
@@ -1,0 +1,5 @@
+---
+"@openapi-generator-plus/swift-client-generator": patch
+---
+
+Ensure the refresh task is reset when errors are thrown

--- a/templates/security/OAuthAccessTokenManager.swift.hbs
+++ b/templates/security/OAuthAccessTokenManager.swift.hbs
@@ -8,7 +8,7 @@ import OSLog
 @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
 private let logger = Logger(subsystem: "{{@root.info.title}}", category: "oauth")
 
-public typealias AccessTokenHandler = (_ accessToken: OAuthAccessToken) -> ()
+public typealias AccessTokenHandler = (_ accessToken: OAuthAccessToken?) -> ()
 
 /** An OAuth access token manager that manages using and refreshing the access token, including handling concurrent requests and refreshes. */
 actor OAuthAccessTokenManager {
@@ -99,6 +99,10 @@ actor OAuthAccessTokenManager {
                 resultData.createdAt = requestDate
                 self.accessToken = resultData
                 self.accessTokenDidChange?(resultData)
+            case 401:
+                self.accessToken = nil
+                self.accessTokenDidChange?(nil)
+                throw APIError.authenticationFailed(result.response, data: result.data)
             default:
                 throw APIError.authenticationFailed(result.response, data: result.data)
             }

--- a/templates/security/OAuthAccessTokenManager.swift.hbs
+++ b/templates/security/OAuthAccessTokenManager.swift.hbs
@@ -109,8 +109,10 @@ actor OAuthAccessTokenManager {
         }
         
         refreshTask = t
+        defer {
+            refreshTask = nil
+        }
         try await t.value
-        refreshTask = nil
     }
 
     func refreshToken(failedRequest: URLRequest) async throws {

--- a/templates/security/OAuthClientCredentialsFlowClient.swift.hbs
+++ b/templates/security/OAuthClientCredentialsFlowClient.swift.hbs
@@ -7,7 +7,7 @@ import Foundation
 /// A client for the OAuth 2.0 Client Credentials Flow
 public class OAuthClientCredentialsFlowClient: AbstractOAuthFlowClient {
     
-    private let authticationManager: AuthenticationManager
+    private let authenticator: Authenticator
     
     public init(clientId: String,
                 clientSecret: String,
@@ -15,13 +15,13 @@ public class OAuthClientCredentialsFlowClient: AbstractOAuthFlowClient {
                 preemptiveAccessTokenRefresh autoRefreshInterval: TimeInterval? = nil,
                 tokenURL: URL,
                 accessTokenDidChange: AccessTokenHandler? = nil) {
-        self.authticationManager = AuthenticationManager(tokenURL: tokenURL)
+        self.authenticator = Authenticator(tokenURL: tokenURL)
         super.init(clientId: clientId, clientSecret: clientSecret, refreshURL: refreshURL, preemptiveAccessTokenRefresh: autoRefreshInterval, accessTokenDidChange: accessTokenDidChange)
     }
     
     /// Authenticate the security client, requesting the given scopes.
     public func authenticate(scopes: [String]?, additionalParams params: [String: String]? = nil) async throws {
-        try await authticationManager.authenticate(scopes: scopes, additionalParams: params, clientId: clientId, clientSecret: clientSecret, tokenManager: tokenManager)
+        try await authenticator.authenticate(scopes: scopes, additionalParams: params, clientId: clientId, clientSecret: clientSecret, tokenManager: tokenManager)
     }
     
     public override func reauthenticate(failedRequest: URLRequest, securityScheme: SecurityScheme, scopes: [String]?) async throws {
@@ -32,7 +32,7 @@ public class OAuthClientCredentialsFlowClient: AbstractOAuthFlowClient {
         }
     }
     
-    private actor AuthenticationManager {
+    private actor Authenticator {
         private let tokenURL: URL
         
         private var authenticateTask: Task<(), Error>?

--- a/templates/security/OAuthClientCredentialsFlowClient.swift.hbs
+++ b/templates/security/OAuthClientCredentialsFlowClient.swift.hbs
@@ -7,7 +7,7 @@ import Foundation
 /// A client for the OAuth 2.0 Client Credentials Flow
 public class OAuthClientCredentialsFlowClient: AbstractOAuthFlowClient {
     
-    private let tokenURL: URL
+    private let authticationManager: AuthenticationManager
     
     public init(clientId: String,
                 clientSecret: String,
@@ -15,35 +15,13 @@ public class OAuthClientCredentialsFlowClient: AbstractOAuthFlowClient {
                 preemptiveAccessTokenRefresh autoRefreshInterval: TimeInterval? = nil,
                 tokenURL: URL,
                 accessTokenDidChange: AccessTokenHandler? = nil) {
-        self.tokenURL = tokenURL
+        self.authticationManager = AuthenticationManager(tokenURL: tokenURL)
         super.init(clientId: clientId, clientSecret: clientSecret, refreshURL: refreshURL, preemptiveAccessTokenRefresh: autoRefreshInterval, accessTokenDidChange: accessTokenDidChange)
     }
     
     /// Authenticate the security client, requesting the given scopes.
     public func authenticate(scopes: [String]?, additionalParams params: [String: String]? = nil) async throws {
-        var form: [String: String] = [
-            "grant_type": "client_credentials",
-            "client_id": clientId,
-            "client_secret": clientSecret
-        ]
-        if let scopes = scopes {
-            form["scope"] = scopes.joined(separator: " ")
-        }
-        if let params = params {
-            form.merge(params, uniquingKeysWith: { (_, new) in new })
-        }
-        let request = createOAuthRequest(url: tokenURL, params: form)
-        
-        let requestDate = Date()
-        let result = try await URLSession.handleApiRequest(request)
-        switch result.response.statusCode {
-        case 200:
-            var resultData = try JSONDecoder().decode(OAuthAccessToken.self, from: result.data)
-            resultData.createdAt = requestDate
-            try await tokenManager.setAccessToken(resultData)
-        default:
-            throw APIError.authenticationFailed(result.response, data: result.data)
-        }
+        try await authticationManager.authenticate(scopes: scopes, additionalParams: params, clientId: clientId, clientSecret: clientSecret, tokenManager: tokenManager)
     }
     
     public override func reauthenticate(failedRequest: URLRequest, securityScheme: SecurityScheme, scopes: [String]?) async throws {
@@ -51,6 +29,56 @@ public class OAuthClientCredentialsFlowClient: AbstractOAuthFlowClient {
             try await super.reauthenticate(failedRequest: failedRequest, securityScheme: securityScheme, scopes: scopes)
         } catch {
             try await authenticate(scopes: scopes)
+        }
+    }
+    
+    private actor AuthenticationManager {
+        private let tokenURL: URL
+        
+        private var authenticateTask: Task<(), Error>?
+        
+        init(tokenURL: URL) {
+            self.tokenURL = tokenURL
+        }
+        
+        func authenticate(scopes: [String]?, additionalParams params: [String: String]? = nil, clientId: String, clientSecret: String, tokenManager: OAuthAccessTokenManager) async throws {
+            
+            if let task = authenticateTask {
+                return try await task.value
+            }
+            
+            let task = Task {
+                var form: [String: String] = [
+                    "grant_type": "client_credentials",
+                    "client_id": clientId,
+                    "client_secret": clientSecret
+                ]
+                if let scopes = scopes {
+                    form["scope"] = scopes.joined(separator: " ")
+                }
+                if let params = params {
+                    form.merge(params, uniquingKeysWith: { (_, new) in new })
+                }
+                let request = createOAuthRequest(url: tokenURL, params: form)
+                
+                let requestDate = Date()
+                let result = try await URLSession.handleApiRequest(request)
+                switch result.response.statusCode {
+                case 200:
+                    var resultData = try JSONDecoder().decode(OAuthAccessToken.self, from: result.data)
+                    resultData.createdAt = requestDate
+                    try await tokenManager.setAccessToken(resultData)
+                default:
+                    throw APIError.authenticationFailed(result.response, data: result.data)
+                }
+            }
+            
+            authenticateTask = task
+            defer {
+                authenticateTask = nil
+            }
+            
+            try await task.value
         }
     }
 }


### PR DESCRIPTION
Fixed an issue where the refresh task is not cleared when an error is thrown.
Applied the actor isolation logic to the credentials flow client to prevent multiple requests to reauthenticate when a token expires.