### PR TITLE
add message to deprecation annotation to display deprecation in Xcode

### DIFF
--- a/.changeset/stupid-rats-retire.md
+++ b/.changeset/stupid-rats-retire.md
@@ -1,0 +1,5 @@
+---
+"@openapi-generator-plus/swift-client-generator": patch
+---
+
+fix deprecation mark in Xcode

--- a/templates/frag/operation.hbs
+++ b/templates/frag/operation.hbs
@@ -46,7 +46,7 @@ public enum {{className name}}Result {
 
 {{>frag/operationDocumentation}}
 {{#if deprecated}}
-@available(*, deprecated)
+@available(*, deprecated, message: "This function is deprecated. Please refer to the provider of the API specification for further instructions.")
 {{/if}}
 open func {{{name}}}(_ __request: {{{className (concat group.name '_' name '_' 'requestable')}}}, {{#if requestBody.nativeType}}{{{requestBody.name}}}: {{{requestBody.nativeType}}}{{#unless requestBody.required}} = nil{{/unless}}, {{/if}}responseQueue: DispatchQueue? = nil, completion: @escaping ((_ result: Result<{{className name}}Result, Error>) -> Void)) {
     {{{name}}}({{{_requestCallParams}}}, responseQueue: responseQueue, completion: completion)
@@ -54,7 +54,7 @@ open func {{{name}}}(_ __request: {{{className (concat group.name '_' name '_' '
 
 {{>frag/operationDocumentation}}
 {{#if deprecated}}
-@available(*, deprecated)
+@available(*, deprecated, message: "This function is deprecated. Please refer to the provider of the API specification for further instructions.")
 {{/if}}
 open func {{{name}}}(_ __request: {{{className (concat group.name '_' name '_' 'requestable')}}}{{#if requestBody.nativeType}}, {{{requestBody.name}}}: {{{requestBody.nativeType}}}{{#unless requestBody.required}} = nil{{/unless}}{{/if}}) async throws -> {{className name}}Result {
     return try await {{{name}}}({{{_requestCallParams}}})
@@ -63,7 +63,7 @@ open func {{{name}}}(_ __request: {{{className (concat group.name '_' name '_' '
 {{/if}}
 {{>frag/operationDocumentation}}
 {{#if deprecated}}
-@available(*, deprecated)
+@available(*, deprecated, message: "This function is deprecated. Please refer to the provider of the API specification for further instructions.")
 {{/if}}
 open func {{{name}}}({{{_params}}}{{#if _params}}, {{/if}}responseQueue: DispatchQueue? = nil, completion: @escaping ((_ result: Result<{{className name}}Result, Error>) -> Void)) {
     let responseQueue = responseQueue ?? configuration.responseQueue
@@ -83,7 +83,7 @@ open func {{{name}}}({{{_params}}}{{#if _params}}, {{/if}}responseQueue: Dispatc
 
 {{>frag/operationDocumentation}}
 {{#if deprecated}}
-@available(*, deprecated)
+@available(*, deprecated, message: "This function is deprecated. Please refer to the provider of the API specification for further instructions.")
 {{/if}}
 open func {{{name}}}({{{_params}}}) async throws -> {{className name}}Result {
     return try await {{{name}}}({{{_callParams}}}{{#if _params}}, {{/if}}allowsReauth: true)

--- a/templates/frag/pojo.hbs
+++ b/templates/frag/pojo.hbs
@@ -1,6 +1,6 @@
 {{>frag/schemaDocumentation}}
 {{#if deprecated}}
-@available(*, deprecated)
+@available(*, deprecated, message: "This object is deprecated. Please refer to the provider of the API specification for further instructions.")
 {{/if}}
 {{#join '_parents' ', '}}
 Swift.Codable
@@ -13,7 +13,7 @@ public struct {{{name}}}: {{{_parents}}} {
 {{#each properties}}
     {{>frag/propertyDocumentation}}
     {{#if deprecated}}
-    @available(*, deprecated)
+    @available(*, deprecated, message: "This property is deprecated. Please refer to the provider of the API specification for further instructions.")
     {{/if}}
     public var {{{name}}}: {{{nativeType}}}
 {{/each}}


### PR DESCRIPTION
# Description
It seems that without the `message` field, `deprecated` flag in `@available()` annotation fails to indicate deprecation in Xcode nor does it display that it's deprecated in documentations visible through the Quick Help pane.

This PR adds a brief message to all the deprecation marks so that Xcode can at least identify deprecated members and objects and correctly indicate deprecations throughout the codebase. 

## Screenshots

### Without `message` field
<img width="2672" alt="Screenshot 2024-07-02 at 11 41 39 AM" src="https://github.com/karlvr/openapi-generator-plus-swift-client-generator/assets/23311189/50b942ad-eea6-4862-aa94-621d5b8b5979">

### With `message` field
<img width="2672" alt="Screenshot 2024-07-02 at 11 42 10 AM" src="https://github.com/karlvr/openapi-generator-plus-swift-client-generator/assets/23311189/2eab6f0b-a7b7-41fe-ae65-c6e8141a7db6">
