### PR TITLE
429 Retry handling and improved token refresh handling and error throwing

### DIFF
--- a/.changeset/gorgeous-cows-teach.md
+++ b/.changeset/gorgeous-cows-teach.md
@@ -1,0 +1,5 @@
+---
+"@openapi-generator-plus/swift-client-generator": minor
+---
+
+Added retry handling for 429 responses

--- a/.changeset/seven-hounds-relax.md
+++ b/.changeset/seven-hounds-relax.md
@@ -1,0 +1,5 @@
+---
+"@openapi-generator-plus/swift-client-generator": patch
+---
+
+Refined refresh token handling of error responses to distinguish between failed authentication and simply an unexpected response

--- a/src/index.ts
+++ b/src/index.ts
@@ -103,7 +103,7 @@ export function options(config: CodegenConfig, context: SwiftGeneratorContext): 
 		relativeSourceOutputPath,
 		customTemplatesPath: customTemplates ? computeCustomTemplatesPath(config.configPath, customTemplates) : null,
 		hideGenerationTimestamp: configBoolean(config, 'hideGenerationTimestamp', false),
-		customRetryStatusCodes: configStringArray(config, 'customRetryStatusCodes', []),
+		additionalRetryStatusCodes: configStringArray(config, 'additionalRetryStatusCodes', []),
 		package: {
 			name: packageName,
 		},

--- a/src/index.ts
+++ b/src/index.ts
@@ -87,7 +87,9 @@ const RESERVED_WORDS = [
 	'try', 'typealias', 'unowned', 'var', 'weak', 'where', 'while', 'willSet',
 	'LocalDate', 'LocalTime', 'OffsetDateTime', 'Decimal', 'String', 'Void', 'File', 'FormData',
 	'unknown', // for our enum cases
-	'RetryConfiguration',
+	'RetryConfiguration', 'Configuration',
+	'SecurityClient', 'SecurityClientController', 'SecurityScheme', 'OAuthPasswordFlowClient', 'OAuthClientCredentialsFlowClient', 'OAuthAuthorizationCodeFlowClient', 
+	'OAuthAccessTokenManager', 'AccessTokenHandler', 'OAuthAccessToken', 'BasicAuthenticationSecurityClient', 'APIKeySecurityClient', 'AbstractOAuthFlowClient',
 ]
 
 export function options(config: CodegenConfig, context: SwiftGeneratorContext): CodegenOptionsSwift {

--- a/src/index.ts
+++ b/src/index.ts
@@ -106,6 +106,7 @@ export function options(config: CodegenConfig, context: SwiftGeneratorContext): 
 		customTemplatesPath: customTemplates ? computeCustomTemplatesPath(config.configPath, customTemplates) : null,
 		hideGenerationTimestamp: configBoolean(config, 'hideGenerationTimestamp', false),
 		additionalRetryStatusCodes: configStringArray(config, 'additionalRetryStatusCodes', []),
+		additionalTokenFailureStatusCodes: configStringArray(config, 'additionalTokenFailureStatusCodes', []),
 		package: {
 			name: packageName,
 		},

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import path from 'path'
 import Handlebars from 'handlebars'
 import { loadTemplates, emit, registerStandardHelpers } from '@openapi-generator-plus/handlebars-templates'
 import { javaLikeGenerator, ConstantStyle, JavaLikeContext, options as javaLikeOptions } from '@openapi-generator-plus/java-like-generator-helper'
-import { commonGenerator, configBoolean, configObject, configString, debugStringify } from '@openapi-generator-plus/generator-common'
+import { commonGenerator, configBoolean, configObject, configString, configStringArray, debugStringify } from '@openapi-generator-plus/generator-common'
 import { promises as fs } from 'fs'
 
 export { CodegenOptionsSwift as CodegenOptionsTypeScript } from './types'
@@ -87,6 +87,7 @@ const RESERVED_WORDS = [
 	'try', 'typealias', 'unowned', 'var', 'weak', 'where', 'while', 'willSet',
 	'LocalDate', 'LocalTime', 'OffsetDateTime', 'Decimal', 'String', 'Void', 'File', 'FormData',
 	'unknown', // for our enum cases
+	'RetryConfiguration',
 ]
 
 export function options(config: CodegenConfig, context: SwiftGeneratorContext): CodegenOptionsSwift {
@@ -102,6 +103,7 @@ export function options(config: CodegenConfig, context: SwiftGeneratorContext): 
 		relativeSourceOutputPath,
 		customTemplatesPath: customTemplates ? computeCustomTemplatesPath(config.configPath, customTemplates) : null,
 		hideGenerationTimestamp: configBoolean(config, 'hideGenerationTimestamp', false),
+		customRetryStatusCodes: configStringArray(config, 'customRetryStatusCodes', []),
 		package: {
 			name: packageName,
 		},

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,7 @@ export interface CodegenOptionsSwift extends JavaLikeOptions {
 	relativeSourceOutputPath: string
 	customTemplatesPath: string | null
 	hideGenerationTimestamp: boolean
+	customRetryStatusCodes: string[]
 	package: {
 		name: string
 	}

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,7 +7,8 @@ export interface CodegenOptionsSwift extends JavaLikeOptions {
 	relativeSourceOutputPath: string
 	customTemplatesPath: string | null
 	hideGenerationTimestamp: boolean
-	customRetryStatusCodes: string[]
+	/** Additional HTTP response status codes that will trigger an automatic retry. 429 Too Many Requests is always automatically retried. */
+	additionalRetryStatusCodes: string[]
 	package: {
 		name: string
 	}

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,8 @@ export interface CodegenOptionsSwift extends JavaLikeOptions {
 	hideGenerationTimestamp: boolean
 	/** Additional HTTP response status codes that will trigger an automatic retry. 429 Too Many Requests is always automatically retried. */
 	additionalRetryStatusCodes: string[]
+	/** Additional HTTP response status codes that will be considered to be an authentication failure. 400 - 499 already result in authentication failure */
+	additionalTokenFailureStatusCodes: string[]
 	package: {
 		name: string
 	}

--- a/templates/frag/operation.hbs
+++ b/templates/frag/operation.hbs
@@ -91,7 +91,7 @@ open func {{{name}}}({{{_params}}}) async throws -> {{className name}}Result {
 
 private func {{{name}}}({{{_params}}}{{#if _params}}, {{/if}}allowsReauth: Bool) async throws -> {{className name}}Result {
     let __request = try await {{{name}}}Request({{{_callParams}}})
-    let result = try await URLSession.handleApiRequest(__request, configuration: configuration.retryConfiguration)
+    let result = try await URLSession.handleApiRequest(__request, retryConfiguration: configuration.retryConfiguration)
     switch result.response.statusCode {
 {{#if securityRequirements}}
     case 401:

--- a/templates/frag/operation.hbs
+++ b/templates/frag/operation.hbs
@@ -91,8 +91,8 @@ open func {{{name}}}({{{_params}}}) async throws -> {{className name}}Result {
 
 private func {{{name}}}({{{_params}}}{{#if _params}}, {{/if}}allowsReauth: Bool) async throws -> {{className name}}Result {
     let __request = try await {{{name}}}Request({{{_callParams}}})
-    let (response, data) = try await URLSession.handleApiRequest(__request)
-    switch response.statusCode {
+    let result = try await URLSession.handleApiRequest(__request, configuration: configuration.retryConfiguration)
+    switch result.response.statusCode {
 {{#if securityRequirements}}
     case 401:
         if allowsReauth, let securityClient = configuration.securityClient {
@@ -117,7 +117,7 @@ private func {{{name}}}({{{_params}}}{{#if _params}}, {{/if}}allowsReauth: Bool)
             {{/unless}}
             return try await {{{name}}}({{{_callParams}}}{{#if _callParams}}, {{/if}}allowsReauth: false)
         } else {
-            throw APIError.authenticationFailed(response, data: data)
+            throw APIError.authenticationFailed(result.response, data: result.data)
         }
 {{/if}}
 {{#each responses}}
@@ -126,10 +126,10 @@ private func {{{name}}}({{{_params}}}{{#if _params}}, {{/if}}allowsReauth: Bool)
     case {{{code}}}:
     {{#if defaultContent.nativeType}}
         do {
-            let decodedData = try JSONDecoder().decode({{{defaultContent.nativeType.concreteType}}}.self, from: data)
+            let decodedData = try JSONDecoder().decode({{{defaultContent.nativeType.concreteType}}}.self, from: result.data)
             return ._{{{code}}}(decodedData)
         } catch {
-            throw APIError.invalidResponse(error, response: response, data: data)
+            throw APIError.invalidResponse(error, response: result.response, data: result.data)
         }
     {{else}}
         return ._{{{code}}}
@@ -141,16 +141,16 @@ private func {{{name}}}({{{_params}}}{{#if _params}}, {{/if}}allowsReauth: Bool)
 {{#if catchAllResponse}}
     {{#if catchAllResponse.defaultContent.nativeType}}
         do {
-            let decodedData = try JSONDecoder().decode({{{catchAllResponse.defaultContent.nativeType.concreteType}}}.self, from: data)
+            let decodedData = try JSONDecoder().decode({{{catchAllResponse.defaultContent.nativeType.concreteType}}}.self, from: result.data)
             return ._{{{catchAllResponse.code}}}(decodedData)
         } catch {
-            throw APIError.invalidResponse(error, response: response, data: data)
+            throw APIError.invalidResponse(error, response: result.response, data: result.data)
         }
     {{else}}
         return ._{{{catchAllResponse.code}}}
     {{/if}}
 {{else}}
-        throw APIError.unexpectedResponse(response, data: data)
+        throw APIError.unexpectedResponse(result.response, data: result.data)
 {{/if}}
     }
 }

--- a/templates/security/AbstractOAuthFlowClient.swift.hbs
+++ b/templates/security/AbstractOAuthFlowClient.swift.hbs
@@ -11,6 +11,7 @@ public class AbstractOAuthFlowClient: SecurityClient {
     let clientId: String
     let clientSecret: String
     public var revocationURL: URL?
+    let retryConfiguration: RetryConfiguration?
     
     public var refreshToken: String? {
          get async {
@@ -24,10 +25,11 @@ public class AbstractOAuthFlowClient: SecurityClient {
         }
     }
 
-    init(clientId: String, clientSecret: String, refreshURL: URL?, preemptiveAccessTokenRefresh autoRefreshInterval: TimeInterval? = nil, accessTokenDidChange: AccessTokenHandler?) {
+    init(clientId: String, clientSecret: String, refreshURL: URL?, preemptiveAccessTokenRefresh autoRefreshInterval: TimeInterval? = nil, retryConfiguration: RetryConfiguration? = nil, accessTokenDidChange: AccessTokenHandler?) {
         self.clientId = clientId
         self.clientSecret = clientSecret
-        self.tokenManager = OAuthAccessTokenManager(clientId: clientId, clientSecret: clientSecret, refreshTokenURL: refreshURL, preemptiveAccessTokenRefresh: autoRefreshInterval, accessTokenDidChange: accessTokenDidChange)
+        self.retryConfiguration = retryConfiguration
+        self.tokenManager = OAuthAccessTokenManager(clientId: clientId, clientSecret: clientSecret, refreshTokenURL: refreshURL, preemptiveAccessTokenRefresh: autoRefreshInterval, retryConfiguration: retryConfiguration, accessTokenDidChange: accessTokenDidChange)
     }
     
     /// Authenticate the security client using a refresh token.

--- a/templates/security/OAuthAccessTokenManager.swift.hbs
+++ b/templates/security/OAuthAccessTokenManager.swift.hbs
@@ -101,7 +101,7 @@ actor OAuthAccessTokenManager {
                 resultData.createdAt = requestDate
                 self.accessToken = resultData
                 self.accessTokenDidChange?(resultData)
-            case 400...428, 430...500:
+            case 400...428, 430...500: /// These status codes indicate a problem with the client's request, or an internal server error, which together we believe are reasonable to treat as meaning that the current refresh token is no longer viable.
                 self.accessToken = nil
                 self.accessTokenDidChange?(nil)
                 throw APIError.authenticationFailed(result.response, data: result.data)

--- a/templates/security/OAuthAccessTokenManager.swift.hbs
+++ b/templates/security/OAuthAccessTokenManager.swift.hbs
@@ -111,7 +111,8 @@ actor OAuthAccessTokenManager {
         }
         
         refreshTask = t
-        defer {            refreshTask = nil
+        defer {
+            refreshTask = nil
         }
         try await t.value
     }

--- a/templates/security/OAuthAccessTokenManager.swift.hbs
+++ b/templates/security/OAuthAccessTokenManager.swift.hbs
@@ -99,12 +99,12 @@ actor OAuthAccessTokenManager {
                 resultData.createdAt = requestDate
                 self.accessToken = resultData
                 self.accessTokenDidChange?(resultData)
-            case 400...499:
+            case 400...428, 430...500:
                 self.accessToken = nil
                 self.accessTokenDidChange?(nil)
                 throw APIError.authenticationFailed(result.response, data: result.data)
             default:
-                throw APIError.authenticationFailed(result.response, data: result.data)
+                throw APIError.unexpectedResponse(result.response, data: result.data)
             }
         }
         

--- a/templates/security/OAuthAccessTokenManager.swift.hbs
+++ b/templates/security/OAuthAccessTokenManager.swift.hbs
@@ -94,7 +94,7 @@ actor OAuthAccessTokenManager {
             // Do the refresh
             let request = createRefreshRequest(refreshToken, url: refreshTokenURL)
             let requestDate = Date()
-            let result = try await URLSession.handleApiRequest(request, configuration: retryConfiguration)
+            let result = try await URLSession.handleApiRequest(request, retryConfiguration: retryConfiguration)
             switch result.response.statusCode {
             case 200:
                 var resultData = try JSONDecoder().decode(OAuthAccessToken.self, from: result.data)
@@ -111,8 +111,7 @@ actor OAuthAccessTokenManager {
         }
         
         refreshTask = t
-        defer {
-            refreshTask = nil
+        defer {            refreshTask = nil
         }
         try await t.value
     }
@@ -179,7 +178,7 @@ actor OAuthAccessTokenManager {
             "client_secret": clientSecret
         ])
         
-        let result = try await URLSession.handleApiRequest(request, configuration: retryConfiguration)
+        let result = try await URLSession.handleApiRequest(request, retryConfiguration: retryConfiguration)
         switch result.response.statusCode {
         case 200:
             self.accessToken?.refreshToken = nil
@@ -201,7 +200,7 @@ actor OAuthAccessTokenManager {
             "client_secret": clientSecret
         ])
         
-        let result = try await URLSession.handleApiRequest(request, configuration: retryConfiguration)
+        let result = try await URLSession.handleApiRequest(request, retryConfiguration: retryConfiguration)
         switch result.response.statusCode {
         case 200:
             self.accessToken?.accessToken = nil

--- a/templates/security/OAuthAccessTokenManager.swift.hbs
+++ b/templates/security/OAuthAccessTokenManager.swift.hbs
@@ -1,3 +1,8 @@
+{{#join '_additionalTokenFailureStatusCodes' ', '}}
+{{#each @root.additionalTokenFailureStatusCodes}}
+{{this}}
+{{/each}}
+{{/join}}
 //  
 //  {{>frag/generatedBy}}
 //
@@ -101,7 +106,7 @@ actor OAuthAccessTokenManager {
                 resultData.createdAt = requestDate
                 self.accessToken = resultData
                 self.accessTokenDidChange?(resultData)
-            case 400...428, 430...500: /// These status codes indicate a problem with the client's request, or an internal server error, which together we believe are reasonable to treat as meaning that the current refresh token is no longer viable.
+            case 400...499{{#if _additionalTokenFailureStatusCodes}}, {{{_additionalTokenFailureStatusCodes}}}{{/if}}: /// These status codes indicate a problem with the client's request which we believe are reasonable to treat as meaning that the current refresh token is no longer viable.
                 self.accessToken = nil
                 self.accessTokenDidChange?(nil)
                 throw APIError.authenticationFailed(result.response, data: result.data)

--- a/templates/security/OAuthAccessTokenManager.swift.hbs
+++ b/templates/security/OAuthAccessTokenManager.swift.hbs
@@ -27,14 +27,16 @@ actor OAuthAccessTokenManager {
     private var refreshTimer: Timer?
     private let prepareRequest: ((_ request: URLRequest) -> URLRequest)?
     private let accessTokenDidChange: AccessTokenHandler?
+    private let retryConfiguration: RetryConfiguration?
     
-    init(clientId: String, clientSecret: String, refreshTokenURL: URL?, preemptiveAccessTokenRefresh: TimeInterval? = nil, prepareRequest: ((_: URLRequest) -> URLRequest)? = nil, accessTokenDidChange: AccessTokenHandler? = nil) {
+    init(clientId: String, clientSecret: String, refreshTokenURL: URL?, preemptiveAccessTokenRefresh: TimeInterval? = nil, retryConfiguration: RetryConfiguration? = nil, prepareRequest: ((_: URLRequest) -> URLRequest)? = nil, accessTokenDidChange: AccessTokenHandler? = nil) {
         self.clientId = clientId
         self.clientSecret = clientSecret
         self.preemptiveAccessTokenRefresh = preemptiveAccessTokenRefresh
         self.prepareRequest = prepareRequest
         self.refreshTokenURL = refreshTokenURL
         self.accessTokenDidChange = accessTokenDidChange
+        self.retryConfiguration = retryConfiguration
     }
         
     private func restartRefreshTimer() {
@@ -92,7 +94,7 @@ actor OAuthAccessTokenManager {
             // Do the refresh
             let request = createRefreshRequest(refreshToken, url: refreshTokenURL)
             let requestDate = Date()
-            let result = try await URLSession.handleApiRequest(request)
+            let result = try await URLSession.handleApiRequest(request, configuration: retryConfiguration)
             switch result.response.statusCode {
             case 200:
                 var resultData = try JSONDecoder().decode(OAuthAccessToken.self, from: result.data)
@@ -177,7 +179,7 @@ actor OAuthAccessTokenManager {
             "client_secret": clientSecret
         ])
         
-        let result = try await URLSession.handleApiRequest(request)
+        let result = try await URLSession.handleApiRequest(request, configuration: retryConfiguration)
         switch result.response.statusCode {
         case 200:
             self.accessToken?.refreshToken = nil
@@ -199,7 +201,7 @@ actor OAuthAccessTokenManager {
             "client_secret": clientSecret
         ])
         
-        let result = try await URLSession.handleApiRequest(request)
+        let result = try await URLSession.handleApiRequest(request, configuration: retryConfiguration)
         switch result.response.statusCode {
         case 200:
             self.accessToken?.accessToken = nil

--- a/templates/security/OAuthAuthorizationCodeFlowClient.swift.hbs
+++ b/templates/security/OAuthAuthorizationCodeFlowClient.swift.hbs
@@ -16,11 +16,12 @@ public class OAuthAuthorizationCodeFlowClient: AbstractOAuthFlowClient {
                 preemptiveAccessTokenRefresh autoRefreshInterval: TimeInterval? = nil,
                 tokenURL: URL,
                 authorizationURL: URL,
+                retryConfiguration: RetryConfiguration?,
                 accessTokenDidChange: AccessTokenHandler? = nil) {
         self.tokenURL = tokenURL
         self.authorizationURL = authorizationURL
         
-        super.init(clientId: clientId, clientSecret: clientSecret, refreshURL: refreshURL, preemptiveAccessTokenRefresh: autoRefreshInterval, accessTokenDidChange: accessTokenDidChange)
+        super.init(clientId: clientId, clientSecret: clientSecret, refreshURL: refreshURL, preemptiveAccessTokenRefresh: autoRefreshInterval, retryConfiguration: retryConfiguration, accessTokenDidChange: accessTokenDidChange)
     }
 
     // TODO: Implement the authorization code client

--- a/templates/security/OAuthClientCredentialsFlowClient.swift.hbs
+++ b/templates/security/OAuthClientCredentialsFlowClient.swift.hbs
@@ -14,14 +14,15 @@ public class OAuthClientCredentialsFlowClient: AbstractOAuthFlowClient {
                 refreshURL: URL? = nil,
                 preemptiveAccessTokenRefresh autoRefreshInterval: TimeInterval? = nil,
                 tokenURL: URL,
+                retryConfiguration: RetryConfiguration?,
                 accessTokenDidChange: AccessTokenHandler? = nil) {
         self.authenticator = Authenticator(tokenURL: tokenURL)
-        super.init(clientId: clientId, clientSecret: clientSecret, refreshURL: refreshURL, preemptiveAccessTokenRefresh: autoRefreshInterval, accessTokenDidChange: accessTokenDidChange)
+        super.init(clientId: clientId, clientSecret: clientSecret, refreshURL: refreshURL, preemptiveAccessTokenRefresh: autoRefreshInterval, retryConfiguration: retryConfiguration, accessTokenDidChange: accessTokenDidChange)
     }
     
     /// Authenticate the security client, requesting the given scopes.
     public func authenticate(scopes: [String]?, additionalParams params: [String: String]? = nil) async throws {
-        try await authenticator.authenticate(scopes: scopes, additionalParams: params, clientId: clientId, clientSecret: clientSecret, tokenManager: tokenManager)
+        try await authenticator.authenticate(scopes: scopes, additionalParams: params, clientId: clientId, clientSecret: clientSecret, tokenManager: tokenManager, retryConfiguration: retryConfiguration)
     }
     
     public override func reauthenticate(failedRequest: URLRequest, securityScheme: SecurityScheme, scopes: [String]?) async throws {
@@ -41,7 +42,7 @@ public class OAuthClientCredentialsFlowClient: AbstractOAuthFlowClient {
             self.tokenURL = tokenURL
         }
         
-        func authenticate(scopes: [String]?, additionalParams params: [String: String]? = nil, clientId: String, clientSecret: String, tokenManager: OAuthAccessTokenManager) async throws {
+        func authenticate(scopes: [String]?, additionalParams params: [String: String]? = nil, clientId: String, clientSecret: String, tokenManager: OAuthAccessTokenManager, retryConfiguration: RetryConfiguration?) async throws {
             
             if let task = authenticateTask {
                 return try await task.value
@@ -62,7 +63,7 @@ public class OAuthClientCredentialsFlowClient: AbstractOAuthFlowClient {
                 let request = createOAuthRequest(url: tokenURL, params: form)
                 
                 let requestDate = Date()
-                let result = try await URLSession.handleApiRequest(request)
+                let result = try await URLSession.handleApiRequest(request, configuration: retryConfiguration)
                 switch result.response.statusCode {
                 case 200:
                     var resultData = try JSONDecoder().decode(OAuthAccessToken.self, from: result.data)

--- a/templates/security/OAuthClientCredentialsFlowClient.swift.hbs
+++ b/templates/security/OAuthClientCredentialsFlowClient.swift.hbs
@@ -63,7 +63,7 @@ public class OAuthClientCredentialsFlowClient: AbstractOAuthFlowClient {
                 let request = createOAuthRequest(url: tokenURL, params: form)
                 
                 let requestDate = Date()
-                let result = try await URLSession.handleApiRequest(request, configuration: retryConfiguration)
+                let result = try await URLSession.handleApiRequest(request, retryConfiguration: retryConfiguration)
                 switch result.response.statusCode {
                 case 200:
                     var resultData = try JSONDecoder().decode(OAuthAccessToken.self, from: result.data)

--- a/templates/security/OAuthPasswordFlowClient.swift.hbs
+++ b/templates/security/OAuthPasswordFlowClient.swift.hbs
@@ -14,9 +14,10 @@ public class OAuthPasswordFlowClient: AbstractOAuthFlowClient {
                 refreshURL: URL? = nil,
                 preemptiveAccessTokenRefresh autoRefreshInterval: TimeInterval? = nil,
                 tokenURL: URL,
+                retryConfiguration: RetryConfiguration?,
                 accessTokenDidChange: AccessTokenHandler? = nil) {
         self.tokenURL = tokenURL
-        super.init(clientId: clientId, clientSecret: clientSecret, refreshURL: refreshURL, preemptiveAccessTokenRefresh: autoRefreshInterval, accessTokenDidChange: accessTokenDidChange)
+        super.init(clientId: clientId, clientSecret: clientSecret, refreshURL: refreshURL, preemptiveAccessTokenRefresh: autoRefreshInterval, retryConfiguration: retryConfiguration, accessTokenDidChange: accessTokenDidChange)
     }
     
     /// Authenticate the security client using username and password credentials, requesting the given scopes.
@@ -37,7 +38,7 @@ public class OAuthPasswordFlowClient: AbstractOAuthFlowClient {
         let request = createOAuthRequest(url: tokenURL, params: form)
         
         let requestDate = Date()
-        let result = try await URLSession.handleApiRequest(request)
+        let result = try await URLSession.handleApiRequest(request, configuration: retryConfiguration)
         switch result.response.statusCode {
         case 200:
             var resultData = try JSONDecoder().decode(OAuthAccessToken.self, from: result.data)

--- a/templates/security/OAuthPasswordFlowClient.swift.hbs
+++ b/templates/security/OAuthPasswordFlowClient.swift.hbs
@@ -38,7 +38,7 @@ public class OAuthPasswordFlowClient: AbstractOAuthFlowClient {
         let request = createOAuthRequest(url: tokenURL, params: form)
         
         let requestDate = Date()
-        let result = try await URLSession.handleApiRequest(request, configuration: retryConfiguration)
+        let result = try await URLSession.handleApiRequest(request, retryConfiguration: retryConfiguration)
         switch result.response.statusCode {
         case 200:
             var resultData = try JSONDecoder().decode(OAuthAccessToken.self, from: result.data)

--- a/templates/security/SecurityScheme.swift.hbs
+++ b/templates/security/SecurityScheme.swift.hbs
@@ -37,8 +37,8 @@ extension OAuthPasswordFlowClient {
         - preemptiveAccessTokenRefresh: Optional time interval defining how many seconds before expiration should an automatic refresh be attempted. By default no refresh is attempted until the API rejects the token.
         - accessTokenDidChange: A closure to be executed when the access token changes. Defaults to `nil`.
     */
-    public static func {{identifier ../name}}Client(clientId: String, clientSecret: String, preemptiveAccessTokenRefresh: TimeInterval? = nil, accessTokenDidChange: AccessTokenHandler? = nil) -> OAuthPasswordFlowClient {
-        OAuthPasswordFlowClient(clientId: clientId, clientSecret: clientSecret{{#if refreshUrl}}, refreshURL: URL(string: "{{{refreshUrl}}}"){{/if}}, preemptiveAccessTokenRefresh: preemptiveAccessTokenRefresh, tokenURL: URL(string: "{{{tokenUrl}}}")!, accessTokenDidChange: accessTokenDidChange)
+    public static func {{identifier ../name}}Client(clientId: String, clientSecret: String, preemptiveAccessTokenRefresh: TimeInterval? = nil, retryConfiguration: RetryConfiguration? = RetryConfiguration(), accessTokenDidChange: AccessTokenHandler? = nil) -> OAuthPasswordFlowClient {
+        OAuthPasswordFlowClient(clientId: clientId, clientSecret: clientSecret{{#if refreshUrl}}, refreshURL: URL(string: "{{{refreshUrl}}}"){{/if}}, preemptiveAccessTokenRefresh: preemptiveAccessTokenRefresh, tokenURL: URL(string: "{{{tokenUrl}}}")!, retryConfiguration: retryConfiguration, accessTokenDidChange: accessTokenDidChange)
     }
 }
 {{/ifeq}}
@@ -53,8 +53,8 @@ extension OAuthClientCredentialsFlowClient {
         - preemptiveAccessTokenRefresh: Optional time interval defining how many seconds before expiration should an automatic refresh be attempted. By default no refresh is attempted until the API rejects the token.
         - accessTokenDidChange: A closure to be executed when the access token changes. Defaults to `nil`.
     */
-    public static func {{identifier ../name}}Client(clientId: String, clientSecret: String, preemptiveAccessTokenRefresh: TimeInterval? = nil, accessTokenDidChange: AccessTokenHandler? = nil) -> OAuthClientCredentialsFlowClient {
-        OAuthClientCredentialsFlowClient(clientId: clientId, clientSecret: clientSecret{{#if refreshUrl}}, refreshURL: URL(string: "{{{refreshUrl}}}"){{/if}}, preemptiveAccessTokenRefresh: preemptiveAccessTokenRefresh, tokenURL: URL(string: "{{{tokenUrl}}}")!, accessTokenDidChange: accessTokenDidChange)
+    public static func {{identifier ../name}}Client(clientId: String, clientSecret: String, preemptiveAccessTokenRefresh: TimeInterval? = nil, retryConfiguration: RetryConfiguration? = RetryConfiguration(), accessTokenDidChange: AccessTokenHandler? = nil) -> OAuthClientCredentialsFlowClient {
+        OAuthClientCredentialsFlowClient(clientId: clientId, clientSecret: clientSecret{{#if refreshUrl}}, refreshURL: URL(string: "{{{refreshUrl}}}"){{/if}}, preemptiveAccessTokenRefresh: preemptiveAccessTokenRefresh, tokenURL: URL(string: "{{{tokenUrl}}}")!, retryConfiguration: retryConfiguration, accessTokenDidChange: accessTokenDidChange)
     }
 }
 {{/ifeq}}
@@ -70,8 +70,8 @@ extension OAuthAuthorizationCodeFlowClient {
         - preemptiveAccessTokenRefresh: Optional time interval defining how many seconds before expiration should an automatic refresh be attempted. By default no refresh is attempted until the API rejects the token.
         - accessTokenDidChange: A closure to be executed when the access token changes. Defaults to `nil`.
     */
-    public static func {{identifier ../name}}Client(clientId: String, clientSecret: String, preemptiveAccessTokenRefresh: TimeInterval? = nil, accessTokenDidChange: AccessTokenHandler? = nil) -> OAuthAuthorizationCodeFlowClient {
-        OAuthAuthorizationCodeFlowClient(clientId: clientId, clientSecret: clientSecret{{#if refreshUrl}}, refreshURL: URL(string: "{{{refreshUrl}}}"){{/if}}, preemptiveAccessTokenRefresh: preemptiveAccessTokenRefresh, tokenURL: URL(string: "{{{tokenUrl}}}")!, authorizationURL: URL(string: "{{{authorizationUrl}}}")!, accessTokenDidChange: accessTokenDidChange)
+    public static func {{identifier ../name}}Client(clientId: String, clientSecret: String, preemptiveAccessTokenRefresh: TimeInterval? = nil, retryConfiguration: RetryConfiguration? = RetryConfiguration(), accessTokenDidChange: AccessTokenHandler? = nil) -> OAuthAuthorizationCodeFlowClient {
+        OAuthAuthorizationCodeFlowClient(clientId: clientId, clientSecret: clientSecret{{#if refreshUrl}}, refreshURL: URL(string: "{{{refreshUrl}}}"){{/if}}, preemptiveAccessTokenRefresh: preemptiveAccessTokenRefresh, tokenURL: URL(string: "{{{tokenUrl}}}")!, authorizationURL: URL(string: "{{{authorizationUrl}}}")!, retryConfiguration: retryConfiguration, accessTokenDidChange: accessTokenDidChange)
     }
 }
 {{/if}}

--- a/templates/support/Configuration.swift.hbs
+++ b/templates/support/Configuration.swift.hbs
@@ -24,6 +24,8 @@ public struct Configuration {
 
     public var finalizeRequestBlock: ConfigurationFinalizeRequestBlock?
 
+    public var retryConfiguration: RetryConfiguration?
+
     public init(
         basePath: Swift.String? = nil,
         cachePolicy: Foundation.URLRequest.CachePolicy? = nil,

--- a/templates/support/RetryConfiguration.swift.hbs
+++ b/templates/support/RetryConfiguration.swift.hbs
@@ -1,0 +1,19 @@
+//  
+//  {{>frag/generatedBy}}
+//
+
+import Foundation
+
+public struct RetryConfiguration {
+    let maxAttempts: Int
+    let delay: TimeInterval
+    let scaleFactor: Double
+    let retryStatusCodes: Set<Int>
+
+    public init(maxAttempts: Int = 4, delay: TimeInterval = 2.0, scaleFactor: Double = 2.0, retryStatusCodes: Set<Int> = [429]) {
+        self.maxAttempts = maxAttempts
+        self.delay = delay
+        self.scaleFactor = scaleFactor
+        self.retryStatusCodes = retryStatusCodes
+    }
+}

--- a/templates/support/RetryConfiguration.swift.hbs
+++ b/templates/support/RetryConfiguration.swift.hbs
@@ -15,14 +15,12 @@ public struct RetryConfiguration {
     /// The factor by which to scale the delay between attempts (exponential backoff)
     let scaleFactor: Double
 
-    /**
-    * Initialize a new RetryConfiguration
-    *
-    * - Parameters:
-    *   - maxAttempts: The maximum number of attempts to make
-    *   - delay: The minimum delay between attempts
-    *   - scaleFactor: The factor by which to scale the delay between attempts (exponential backoff)
-    */
+    /// Initialize a new RetryConfiguration
+    /// 
+    /// - Parameters:
+    ///   - maxAttempts: The maximum number of attempts to make
+    ///   - delay: The minimum delay between attempts
+    ///   - scaleFactor: The factor by which to scale the delay between attempts (exponential backoff)
     public init(maxAttempts: Int = 4, delay: TimeInterval = 2.0, scaleFactor: Double = 2.0) {
         self.maxAttempts = maxAttempts
         self.delay = delay

--- a/templates/support/RetryConfiguration.swift.hbs
+++ b/templates/support/RetryConfiguration.swift.hbs
@@ -4,16 +4,28 @@
 
 import Foundation
 
+/// A configuration for retrying requests
 public struct RetryConfiguration {
+    /// The maximum number of attempts to make
     let maxAttempts: Int
-    let delay: TimeInterval
-    let scaleFactor: Double
-    let retryStatusCodes: Set<Int>
 
-    public init(maxAttempts: Int = 4, delay: TimeInterval = 2.0, scaleFactor: Double = 2.0, retryStatusCodes: Set<Int> = [429]) {
+    /// The minimum delay between attempts
+    let delay: TimeInterval
+
+    /// The factor by which to scale the delay between attempts (exponential backoff)
+    let scaleFactor: Double
+
+    /**
+    * Initialize a new RetryConfiguration
+    *
+    * - Parameters:
+    *   - maxAttempts: The maximum number of attempts to make
+    *   - delay: The minimum delay between attempts
+    *   - scaleFactor: The factor by which to scale the delay between attempts (exponential backoff)
+    */
+    public init(maxAttempts: Int = 4, delay: TimeInterval = 2.0, scaleFactor: Double = 2.0) {
         self.maxAttempts = maxAttempts
         self.delay = delay
         self.scaleFactor = scaleFactor
-        self.retryStatusCodes = retryStatusCodes
     }
 }

--- a/templates/support/URLSession+Api.swift.hbs
+++ b/templates/support/URLSession+Api.swift.hbs
@@ -9,10 +9,10 @@ extension Foundation.URLSession {
     static var apiSession = Foundation.URLSession(configuration: .default)
 
     @available(*, renamed: "handleApiRequest(_:)")
-    static func handleApiRequest(_ request: Foundation.URLRequest, configuration: RetryConfiguration?, completion: @escaping ((_ response: Foundation.HTTPURLResponse?, _ data: Data?, _ error: Error?) -> Void)) {
+    static func handleApiRequest(_ request: Foundation.URLRequest, retryConfiguration: RetryConfiguration?, completion: @escaping ((_ response: Foundation.HTTPURLResponse?, _ data: Data?, _ error: Error?) -> Void)) {
         Task {
             do {
-                let result = try await handleApiRequest(request, configuration: configuration)
+                let result = try await handleApiRequest(request, retryConfiguration: retryConfiguration)
                 completion(result.response, result.data, nil)
             } catch {
                 completion(nil, nil, error)
@@ -20,7 +20,7 @@ extension Foundation.URLSession {
         }
     }
     
-    static func handleApiRequest(_ request: Foundation.URLRequest, attemptsTried: Int = 0, configuration: RetryConfiguration?) async throws -> URLSessionResponse {
+    static func handleApiRequest(_ request: Foundation.URLRequest, attemptsTried: Int = 0, retryConfiguration: RetryConfiguration?) async throws -> URLSessionResponse {
         let (data, response) = try await apiSession.data(for: request)
         guard let httpResponse = response as? HTTPURLResponse else {
             throw APIError.unexpectedResponse(response, data: data)
@@ -29,16 +29,22 @@ extension Foundation.URLSession {
         let nanosecondsPerSecond: Double = 1_000_000_000
 
         let result = URLSessionResponse(response: httpResponse, data: data)
-        guard let configuration = configuration else {
+        guard let retryConfiguration = retryConfiguration else {
             return result
         }
 
-        if (configuration.retryStatusCodes.contains(result.response.statusCode) && attemptsTried < configuration.maxAttempts) {
-            let delay = pow(configuration.scaleFactor, Double(attemptsTried)) * configuration.delay
-            try await Task.sleep(nanoseconds: UInt64(delay * nanosecondsPerSecond))
-            return try await URLSession.handleApiRequest(request, attemptsTried: attemptsTried + 1, configuration: configuration)
+        guard attemptsTried < retryConfiguration.maxAttempts else {
+            return result
         }
-        return result
+
+        switch result.response.statusCode {
+            case 429{{#each @root.customRetryStatusCodes}}{{#ifneq this 429}}, {{this}}{{/ifneq}}{{/each}}:
+                let delay = pow(retryConfiguration.scaleFactor, Double(attemptsTried)) * retryConfiguration.delay
+                try await Task.sleep(nanoseconds: UInt64(delay * nanosecondsPerSecond))
+                return try await URLSession.handleApiRequest(request, attemptsTried: attemptsTried + 1, retryConfiguration: retryConfiguration)
+            default:
+                return result
+        }
     }
 }
 

--- a/templates/support/URLSession+Api.swift.hbs
+++ b/templates/support/URLSession+Api.swift.hbs
@@ -38,7 +38,7 @@ extension Foundation.URLSession {
         }
 
         switch result.response.statusCode {
-            case 429{{#each @root.customRetryStatusCodes}}{{#ifneq this 429}}, {{this}}{{/ifneq}}{{/each}}:
+            case 429{{#each @root.additionalRetryStatusCodes}}{{#ifneq this 429}}, {{this}}{{/ifneq}}{{/each}}:
                 let delay = pow(retryConfiguration.scaleFactor, Double(attemptsTried)) * retryConfiguration.delay
                 try await Task.sleep(nanoseconds: UInt64(delay * nanosecondsPerSecond))
                 return try await URLSession.handleApiRequest(request, attemptsTried: attemptsTried + 1, retryConfiguration: retryConfiguration)

--- a/templates/support/URLSession+Api.swift.hbs
+++ b/templates/support/URLSession+Api.swift.hbs
@@ -9,10 +9,10 @@ extension Foundation.URLSession {
     static var apiSession = Foundation.URLSession(configuration: .default)
 
     @available(*, renamed: "handleApiRequest(_:)")
-    static func handleApiRequest(_ request: Foundation.URLRequest, completion: @escaping ((_ response: Foundation.HTTPURLResponse?, _ data: Data?, _ error: Error?) -> Void)) {
+    static func handleApiRequest(_ request: Foundation.URLRequest, configuration: RetryConfiguration?, completion: @escaping ((_ response: Foundation.HTTPURLResponse?, _ data: Data?, _ error: Error?) -> Void)) {
         Task {
             do {
-                let result = try await handleApiRequest(request)
+                let result = try await handleApiRequest(request, configuration: configuration)
                 completion(result.response, result.data, nil)
             } catch {
                 completion(nil, nil, error)
@@ -20,11 +20,29 @@ extension Foundation.URLSession {
         }
     }
     
-    static func handleApiRequest(_ request: Foundation.URLRequest) async throws -> (response: HTTPURLResponse, data: Data) {
+    static func handleApiRequest(_ request: Foundation.URLRequest, attemptsTried: Int = 0, configuration: RetryConfiguration?) async throws -> URLSessionResponse {
         let (data, response) = try await apiSession.data(for: request)
         guard let httpResponse = response as? HTTPURLResponse else {
             throw APIError.unexpectedResponse(response, data: data)
         }
-        return (response: httpResponse, data: data)
+
+        let nanosecondsPerSecond: Double = 1_000_000_000
+
+        let result = URLSessionResponse(response: httpResponse, data: data)
+        guard let configuration = configuration else {
+            return result
+        }
+
+        if (configuration.retryStatusCodes.contains(result.response.statusCode) && attemptsTried < configuration.maxAttempts) {
+            let delay = pow(configuration.scaleFactor, Double(attemptsTried)) * configuration.delay
+            try await Task.sleep(nanoseconds: UInt64(delay * nanosecondsPerSecond))
+            return try await URLSession.handleApiRequest(request, attemptsTried: attemptsTried + 1, configuration: configuration)
+        }
+        return result
     }
+}
+
+struct URLSessionResponse {
+    let response: HTTPURLResponse
+    let data: Data
 }

--- a/templates/support/URLSession+Api.swift.hbs
+++ b/templates/support/URLSession+Api.swift.hbs
@@ -33,12 +33,11 @@ extension Foundation.URLSession {
             return result
         }
 
-        guard attemptsTried < retryConfiguration.maxAttempts else {
-            return result
-        }
-
         switch result.response.statusCode {
             case 429{{#each @root.additionalRetryStatusCodes}}{{#ifneq this 429}}, {{this}}{{/ifneq}}{{/each}}:
+                if attemptsTried >= retryConfiguration.maxAttempts {
+                    throw APIError.unexpectedResponse(response, data: data)
+                }
                 let delay = pow(retryConfiguration.scaleFactor, Double(attemptsTried)) * retryConfiguration.delay
                 try await Task.sleep(nanoseconds: UInt64(delay * nanosecondsPerSecond))
                 return try await URLSession.handleApiRequest(request, attemptsTried: attemptsTried + 1, retryConfiguration: retryConfiguration)


### PR DESCRIPTION
Refined refresh token handling of error responses to distinguish between failed authentication and simply an unexpected response.

Added retry handling of 429 responses. Using a custom configuration as some providers emit status codes that are not 429 but the best strategy to resolve it is to simply retry.