### PR TITLE
Refactor logging to be a runtime option via configuration

### DIFF
--- a/.changeset/few-bees-juggle.md
+++ b/.changeset/few-bees-juggle.md
@@ -1,0 +1,5 @@
+---
+"@openapi-generator-plus/swift-client-generator": patch
+---
+
+Increased the version number of supported operating systems

--- a/.changeset/thick-dodos-run.md
+++ b/.changeset/thick-dodos-run.md
@@ -1,0 +1,5 @@
+---
+"@openapi-generator-plus/swift-client-generator": minor
+---
+
+Added configurations for OAuth flows

--- a/.changeset/two-wasps-refuse.md
+++ b/.changeset/two-wasps-refuse.md
@@ -1,0 +1,5 @@
+---
+"@openapi-generator-plus/swift-client-generator": patch
+---
+
+Use a logging flag for controlling logging at runtime

--- a/src/index.ts
+++ b/src/index.ts
@@ -90,6 +90,7 @@ const RESERVED_WORDS = [
 	'RetryConfiguration', 'Configuration',
 	'SecurityClient', 'SecurityClientController', 'SecurityScheme', 'OAuthPasswordFlowClient', 'OAuthClientCredentialsFlowClient', 'OAuthAuthorizationCodeFlowClient', 
 	'OAuthAccessTokenManager', 'AccessTokenHandler', 'OAuthAccessToken', 'BasicAuthenticationSecurityClient', 'APIKeySecurityClient', 'AbstractOAuthFlowClient',
+	'OAuthConfiguration',
 ]
 
 export function options(config: CodegenConfig, context: SwiftGeneratorContext): CodegenOptionsSwift {

--- a/src/index.ts
+++ b/src/index.ts
@@ -113,7 +113,6 @@ export function options(config: CodegenConfig, context: SwiftGeneratorContext): 
 			name: packageName,
 		},
 		logging: {
-			enabled: configBoolean(logging, 'enabled', false, 'logging.'),
 			subsystem: configString(logging, 'subsystem', packageName, 'logging.'),
 		},
 	}

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,7 +15,6 @@ export interface CodegenOptionsSwift extends JavaLikeOptions {
 		name: string
 	}
 	logging: {
-		enabled: boolean
 		subsystem: string
 	}
 }

--- a/templates/Package.hbs
+++ b/templates/Package.hbs
@@ -1,4 +1,4 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.3
 
 import PackageDescription
 
@@ -6,10 +6,10 @@ import PackageDescription
 let package = Package(
     name: "{{{name}}}",
     platforms: [
-        .iOS(.v13),
-        .macOS(.v10_15),
-        .tvOS(.v13),
-        .watchOS(.v3),
+        .iOS(.v14),
+        .macOS(.v11),
+        .tvOS(.v14),
+        .watchOS(.v7),
     ],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.

--- a/templates/frag/log.hbs
+++ b/templates/frag/log.hbs
@@ -1,7 +1,1 @@
-{{#if @root.logging.enabled}}
-if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
-    logger.{{{level}}}("{{{msg}}}")
-} else {
-    print("[{{@root.logging.subsystem}}] [{{{level}}}]: {{{msg}}}")
-}
-{{/if}}
+if {{#if (ifdef condition)}}{{{condition}}}{{else}}configuration.loggingEnabled{{/if}} { logger.{{{level}}}("{{{msg}}}") }

--- a/templates/frag/logHeader.hbs
+++ b/templates/frag/logHeader.hbs
@@ -1,6 +1,3 @@
-{{#if @root.logging.enabled}}
 import OSLog
 
-@available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
 private let logger = Logger(subsystem: "{{@root.logging.subsystem}}", category: "{{{category}}}")
-{{/if}}

--- a/templates/security/AbstractOAuthFlowClient.swift.hbs
+++ b/templates/security/AbstractOAuthFlowClient.swift.hbs
@@ -11,7 +11,7 @@ public class AbstractOAuthFlowClient: SecurityClient {
     let clientId: String
     let clientSecret: String
     public var revocationURL: URL?
-    let retryConfiguration: RetryConfiguration?
+    let configuration: OAuthConfiguration
     
     public var refreshToken: String? {
          get async {
@@ -25,11 +25,11 @@ public class AbstractOAuthFlowClient: SecurityClient {
         }
     }
 
-    init(clientId: String, clientSecret: String, token: OAuthAccessToken?, refreshURL: URL?, preemptiveAccessTokenRefresh autoRefreshInterval: TimeInterval? = nil, retryConfiguration: RetryConfiguration? = nil, accessTokenDidChange: AccessTokenHandler?) {
+    init(clientId: String, clientSecret: String, token: OAuthAccessToken?, refreshURL: URL?, configuration: OAuthConfiguration = OAuthConfiguration()) {
         self.clientId = clientId
         self.clientSecret = clientSecret
-        self.retryConfiguration = retryConfiguration
-        self.tokenManager = OAuthAccessTokenManager(clientId: clientId, clientSecret: clientSecret, token: token, refreshTokenURL: refreshURL, preemptiveAccessTokenRefresh: autoRefreshInterval, retryConfiguration: retryConfiguration, accessTokenDidChange: accessTokenDidChange)
+        self.configuration = configuration
+        self.tokenManager = OAuthAccessTokenManager(clientId: clientId, clientSecret: clientSecret, token: token, refreshTokenURL: refreshURL, configuration: configuration)
     }
     
     /// Authenticate the security client using a refresh token.

--- a/templates/security/OAuthAccessTokenManager.swift.hbs
+++ b/templates/security/OAuthAccessTokenManager.swift.hbs
@@ -24,22 +24,16 @@ actor OAuthAccessTokenManager {
     private let clientId: String
     private let clientSecret: String
     private let refreshTokenURL: URL?
-    private let preemptiveAccessTokenRefresh: TimeInterval?
     private var refreshTask: Task<(), Error>?
     private var refreshTimer: Timer?
-    private let prepareRequest: ((_ request: URLRequest) -> URLRequest)?
-    private let accessTokenDidChange: AccessTokenHandler?
-    private let retryConfiguration: RetryConfiguration?
+    private let configuration: OAuthConfiguration
     
-    init(clientId: String, clientSecret: String, token: OAuthAccessToken?, refreshTokenURL: URL?, preemptiveAccessTokenRefresh: TimeInterval? = nil, retryConfiguration: RetryConfiguration? = nil, prepareRequest: ((_: URLRequest) -> URLRequest)? = nil, accessTokenDidChange: AccessTokenHandler? = nil) {
+    init(clientId: String, clientSecret: String, token: OAuthAccessToken?, refreshTokenURL: URL?, configuration: OAuthConfiguration) {
         self.clientId = clientId
         self.clientSecret = clientSecret
-        self.preemptiveAccessTokenRefresh = preemptiveAccessTokenRefresh
-        self.prepareRequest = prepareRequest
         self.refreshTokenURL = refreshTokenURL
-        self.accessTokenDidChange = accessTokenDidChange
-        self.retryConfiguration = retryConfiguration
         self.accessToken = token
+        self.configuration = configuration
     }
         
     private func restartRefreshTimer() {
@@ -47,7 +41,7 @@ actor OAuthAccessTokenManager {
         refreshTimer = nil
         
         guard 
-            let autoTime = preemptiveAccessTokenRefresh,
+            let autoTime = configuration.preemptiveAccessTokenRefresh,
             let token = accessToken, 
             let expiresIn = token.expiresIn,
             expiresIn - autoTime > 0
@@ -60,7 +54,7 @@ actor OAuthAccessTokenManager {
                 do {
                     try await self.refreshToken()
                 } catch {
-                    {{>frag/log level='error' msg='An error occurred in the automatic OAuth access token refresh:: \(error)'}}
+                    {{>frag/log condition='self.configuration.loggingEnabled' level='error' msg='An error occurred in the automatic OAuth access token refresh:: \(error)'}}
                 }
             }
         })
@@ -68,7 +62,7 @@ actor OAuthAccessTokenManager {
     
     func setAccessToken(_ token: OAuthAccessToken) async throws {
         accessToken = token
-        accessTokenDidChange?(token)
+        configuration.accessTokenDidChange?(token)
     }
     
     func refreshToken() async throws {
@@ -99,18 +93,18 @@ actor OAuthAccessTokenManager {
             {{>frag/log level='debug' msg='Performing refresh request'}}
             let request = createRefreshRequest(refreshToken, url: refreshTokenURL)
             let requestDate = Date()
-            let result = try await URLSession.handleApiRequest(request, retryConfiguration: retryConfiguration)
+            let result = try await URLSession.handleApiRequest(request, retryConfiguration: configuration.retryConfiguration)
             switch result.response.statusCode {
             case 200:
                 {{>frag/log level='debug' msg='Refresh request succeeded'}}
                 var resultData = try JSONDecoder().decode(OAuthAccessToken.self, from: result.data)
                 resultData.createdAt = requestDate
                 self.accessToken = resultData
-                self.accessTokenDidChange?(resultData)
+                self.configuration.accessTokenDidChange?(resultData)
             case 400...499{{#if _additionalTokenFailureStatusCodes}}, {{{_additionalTokenFailureStatusCodes}}}{{/if}}: /// These status codes indicate a problem with the client's request which we believe are reasonable to treat as meaning that the current refresh token is no longer viable.
                 {{>frag/log level='error' msg='Refresh request failed with status code \(result.response.statusCode)'}}
                 self.accessToken = nil
-                self.accessTokenDidChange?(nil)
+                self.configuration.accessTokenDidChange?(nil)
                 throw APIError.authenticationFailed(result.response, data: result.data)
             default:
                 {{>frag/log level='error' msg='Refresh request had unexpected response with status code \(result.response.statusCode)'}}
@@ -190,7 +184,7 @@ actor OAuthAccessTokenManager {
             "client_secret": clientSecret
         ])
         
-        let result = try await URLSession.handleApiRequest(request, retryConfiguration: retryConfiguration)
+        let result = try await URLSession.handleApiRequest(request, retryConfiguration: configuration.retryConfiguration)
         switch result.response.statusCode {
         case 200:
             self.accessToken?.refreshToken = nil
@@ -214,7 +208,7 @@ actor OAuthAccessTokenManager {
             "client_secret": clientSecret
         ])
         
-        let result = try await URLSession.handleApiRequest(request, retryConfiguration: retryConfiguration)
+        let result = try await URLSession.handleApiRequest(request, retryConfiguration: configuration.retryConfiguration)
         switch result.response.statusCode {
         case 200:
             self.accessToken?.accessToken = nil

--- a/templates/security/OAuthAuthorizationCodeFlowClient.swift.hbs
+++ b/templates/security/OAuthAuthorizationCodeFlowClient.swift.hbs
@@ -14,15 +14,13 @@ public class OAuthAuthorizationCodeFlowClient: AbstractOAuthFlowClient {
                 clientSecret: String,
                 token: OAuthAccessToken? = nil,
                 refreshURL: URL? = nil,
-                preemptiveAccessTokenRefresh autoRefreshInterval: TimeInterval? = nil,
                 tokenURL: URL,
                 authorizationURL: URL,
-                retryConfiguration: RetryConfiguration?,
-                accessTokenDidChange: AccessTokenHandler? = nil) {
+                configuration: OAuthConfiguration = OAuthConfiguration()) {
         self.tokenURL = tokenURL
         self.authorizationURL = authorizationURL
         
-        super.init(clientId: clientId, clientSecret: clientSecret, token: token, refreshURL: refreshURL, preemptiveAccessTokenRefresh: autoRefreshInterval, retryConfiguration: retryConfiguration, accessTokenDidChange: accessTokenDidChange)
+        super.init(clientId: clientId, clientSecret: clientSecret, token: token, refreshURL: refreshURL, configuration: configuration)
     }
 
     // TODO: Implement the authorization code client

--- a/templates/security/OAuthClientCredentialsFlowClient.swift.hbs
+++ b/templates/security/OAuthClientCredentialsFlowClient.swift.hbs
@@ -13,17 +13,15 @@ public class OAuthClientCredentialsFlowClient: AbstractOAuthFlowClient {
                 clientSecret: String,
                 token: OAuthAccessToken? = nil,
                 refreshURL: URL? = nil,
-                preemptiveAccessTokenRefresh autoRefreshInterval: TimeInterval? = nil,
                 tokenURL: URL,
-                retryConfiguration: RetryConfiguration?,
-                accessTokenDidChange: AccessTokenHandler? = nil) {
-        self.authenticator = Authenticator(tokenURL: tokenURL)
-        super.init(clientId: clientId, clientSecret: clientSecret, token: token, refreshURL: refreshURL, preemptiveAccessTokenRefresh: autoRefreshInterval, retryConfiguration: retryConfiguration, accessTokenDidChange: accessTokenDidChange)
+                configuration: OAuthConfiguration = OAuthConfiguration()) {
+        self.authenticator = Authenticator(tokenURL: tokenURL, configuration:configuration)
+        super.init(clientId: clientId, clientSecret: clientSecret, token: token, refreshURL: refreshURL, configuration: configuration)
     }
     
     /// Authenticate the security client, requesting the given scopes.
     public func authenticate(scopes: [String]?, additionalParams params: [String: String]? = nil) async throws {
-        try await authenticator.authenticate(scopes: scopes, additionalParams: params, clientId: clientId, clientSecret: clientSecret, tokenManager: tokenManager, retryConfiguration: retryConfiguration)
+        try await authenticator.authenticate(scopes: scopes, additionalParams: params, clientId: clientId, clientSecret: clientSecret, tokenManager: tokenManager)
     }
     
     public override func reauthenticate(failedRequest: URLRequest, securityScheme: SecurityScheme, scopes: [String]?) async throws {
@@ -36,14 +34,16 @@ public class OAuthClientCredentialsFlowClient: AbstractOAuthFlowClient {
     
     private actor Authenticator {
         private let tokenURL: URL
+        private let configuration: OAuthConfiguration
         
         private var authenticateTask: Task<(), Error>?
         
-        init(tokenURL: URL) {
+        init(tokenURL: URL, configuration: OAuthConfiguration) {
             self.tokenURL = tokenURL
+            self.configuration = configuration
         }
         
-        func authenticate(scopes: [String]?, additionalParams params: [String: String]? = nil, clientId: String, clientSecret: String, tokenManager: OAuthAccessTokenManager, retryConfiguration: RetryConfiguration?) async throws {
+        func authenticate(scopes: [String]?, additionalParams params: [String: String]? = nil, clientId: String, clientSecret: String, tokenManager: OAuthAccessTokenManager) async throws {
             
             if let task = authenticateTask {
                 return try await task.value
@@ -64,7 +64,7 @@ public class OAuthClientCredentialsFlowClient: AbstractOAuthFlowClient {
                 let request = createOAuthRequest(url: tokenURL, params: form)
                 
                 let requestDate = Date()
-                let result = try await URLSession.handleApiRequest(request, retryConfiguration: retryConfiguration)
+                let result = try await URLSession.handleApiRequest(request, retryConfiguration: configuration.retryConfiguration)
                 switch result.response.statusCode {
                 case 200:
                     var resultData = try JSONDecoder().decode(OAuthAccessToken.self, from: result.data)

--- a/templates/security/OAuthPasswordFlowClient.swift.hbs
+++ b/templates/security/OAuthPasswordFlowClient.swift.hbs
@@ -13,12 +13,10 @@ public class OAuthPasswordFlowClient: AbstractOAuthFlowClient {
                 clientSecret: String,
                 token: OAuthAccessToken? = nil,
                 refreshURL: URL? = nil,
-                preemptiveAccessTokenRefresh autoRefreshInterval: TimeInterval? = nil,
                 tokenURL: URL,
-                retryConfiguration: RetryConfiguration?,
-                accessTokenDidChange: AccessTokenHandler? = nil) {
+                configuration: OAuthConfiguration = OAuthConfiguration()) {
         self.tokenURL = tokenURL
-        super.init(clientId: clientId, clientSecret: clientSecret, token: token, refreshURL: refreshURL, preemptiveAccessTokenRefresh: autoRefreshInterval, retryConfiguration: retryConfiguration, accessTokenDidChange: accessTokenDidChange)
+        super.init(clientId: clientId, clientSecret: clientSecret, token: token, refreshURL: refreshURL, configuration: configuration)
     }
     
     /// Authenticate the security client using username and password credentials, requesting the given scopes.
@@ -39,7 +37,7 @@ public class OAuthPasswordFlowClient: AbstractOAuthFlowClient {
         let request = createOAuthRequest(url: tokenURL, params: form)
         
         let requestDate = Date()
-        let result = try await URLSession.handleApiRequest(request, retryConfiguration: retryConfiguration)
+        let result = try await URLSession.handleApiRequest(request, retryConfiguration: configuration.retryConfiguration)
         switch result.response.statusCode {
         case 200:
             var resultData = try JSONDecoder().decode(OAuthAccessToken.self, from: result.data)

--- a/templates/security/SecurityScheme.swift.hbs
+++ b/templates/security/SecurityScheme.swift.hbs
@@ -37,8 +37,8 @@ extension OAuthPasswordFlowClient {
         - preemptiveAccessTokenRefresh: Optional time interval defining how many seconds before expiration should an automatic refresh be attempted. By default no refresh is attempted until the API rejects the token.
         - accessTokenDidChange: A closure to be executed when the access token changes. Defaults to `nil`.
     */
-    public static func {{identifier ../name}}Client(clientId: String, clientSecret: String, token: OAuthAccessToken? = nil, preemptiveAccessTokenRefresh: TimeInterval? = nil, retryConfiguration: RetryConfiguration? = RetryConfiguration(), accessTokenDidChange: AccessTokenHandler? = nil) -> OAuthPasswordFlowClient {
-        OAuthPasswordFlowClient(clientId: clientId, clientSecret: clientSecret{{#if refreshUrl}}, token: token, refreshURL: URL(string: "{{{refreshUrl}}}"){{/if}}, preemptiveAccessTokenRefresh: preemptiveAccessTokenRefresh, tokenURL: URL(string: "{{{tokenUrl}}}")!, retryConfiguration: retryConfiguration, accessTokenDidChange: accessTokenDidChange)
+    public static func {{identifier ../name}}Client(clientId: String, clientSecret: String, token: OAuthAccessToken? = nil, configuration: OAuthConfiguration = OAuthConfiguration()) -> OAuthPasswordFlowClient {
+        OAuthPasswordFlowClient(clientId: clientId, clientSecret: clientSecret{{#if refreshUrl}}, token: token, refreshURL: URL(string: "{{{refreshUrl}}}"){{/if}}, tokenURL: URL(string: "{{{tokenUrl}}}")!, configuration: configuration)
     }
 }
 {{/ifeq}}
@@ -53,8 +53,8 @@ extension OAuthClientCredentialsFlowClient {
         - preemptiveAccessTokenRefresh: Optional time interval defining how many seconds before expiration should an automatic refresh be attempted. By default no refresh is attempted until the API rejects the token.
         - accessTokenDidChange: A closure to be executed when the access token changes. Defaults to `nil`.
     */
-    public static func {{identifier ../name}}Client(clientId: String, clientSecret: String, token: OAuthAccessToken? = nil, preemptiveAccessTokenRefresh: TimeInterval? = nil, retryConfiguration: RetryConfiguration? = RetryConfiguration(), accessTokenDidChange: AccessTokenHandler? = nil) -> OAuthClientCredentialsFlowClient {
-        OAuthClientCredentialsFlowClient(clientId: clientId, clientSecret: clientSecret{{#if refreshUrl}}, token: token, refreshURL: URL(string: "{{{refreshUrl}}}"){{/if}}, preemptiveAccessTokenRefresh: preemptiveAccessTokenRefresh, tokenURL: URL(string: "{{{tokenUrl}}}")!, retryConfiguration: retryConfiguration, accessTokenDidChange: accessTokenDidChange)
+    public static func {{identifier ../name}}Client(clientId: String, clientSecret: String, token: OAuthAccessToken? = nil, configuration: OAuthConfiguration = OAuthConfiguration()) -> OAuthClientCredentialsFlowClient {
+        OAuthClientCredentialsFlowClient(clientId: clientId, clientSecret: clientSecret{{#if refreshUrl}}, token: token, refreshURL: URL(string: "{{{refreshUrl}}}"){{/if}}, tokenURL: URL(string: "{{{tokenUrl}}}")!, configuration: configuration)
     }
 }
 {{/ifeq}}
@@ -70,8 +70,8 @@ extension OAuthAuthorizationCodeFlowClient {
         - preemptiveAccessTokenRefresh: Optional time interval defining how many seconds before expiration should an automatic refresh be attempted. By default no refresh is attempted until the API rejects the token.
         - accessTokenDidChange: A closure to be executed when the access token changes. Defaults to `nil`.
     */
-    public static func {{identifier ../name}}Client(clientId: String, clientSecret: String, token: OAuthAccessToken?, preemptiveAccessTokenRefresh: TimeInterval? = nil, retryConfiguration: RetryConfiguration? = RetryConfiguration(), accessTokenDidChange: AccessTokenHandler? = nil) -> OAuthAuthorizationCodeFlowClient {
-        OAuthAuthorizationCodeFlowClient(clientId: clientId, clientSecret: clientSecret{{#if refreshUrl}}, token: token, refreshURL: URL(string: "{{{refreshUrl}}}"){{/if}}, preemptiveAccessTokenRefresh: preemptiveAccessTokenRefresh, tokenURL: URL(string: "{{{tokenUrl}}}")!, authorizationURL: URL(string: "{{{authorizationUrl}}}")!, retryConfiguration: retryConfiguration, accessTokenDidChange: accessTokenDidChange)
+    public static func {{identifier ../name}}Client(clientId: String, clientSecret: String, token: OAuthAccessToken?, configuration: OAuthConfiguration = OAuthConfiguration()) -> OAuthAuthorizationCodeFlowClient {
+        OAuthAuthorizationCodeFlowClient(clientId: clientId, clientSecret: clientSecret{{#if refreshUrl}}, token: token, refreshURL: URL(string: "{{{refreshUrl}}}"){{/if}}, tokenURL: URL(string: "{{{tokenUrl}}}")!, authorizationURL: URL(string: "{{{authorizationUrl}}}")!, configuration: configuration)
     }
 }
 {{/if}}

--- a/templates/support/Configuration.swift.hbs
+++ b/templates/support/Configuration.swift.hbs
@@ -26,12 +26,15 @@ public struct Configuration {
 
     public var retryConfiguration: RetryConfiguration?
 
+    public var loggingEnabled: Bool
+
     public init(
         basePath: Swift.String? = nil,
         cachePolicy: Foundation.URLRequest.CachePolicy? = nil,
         timeoutInterval: Foundation.TimeInterval = 30,
         responseQueue: Dispatch.DispatchQueue? = nil,
         securityClient: SecurityClient? = nil,
+        loggingEnabled: Bool = false,
         finalizeRequestBlock: ConfigurationFinalizeRequestBlock? = nil
     ) {
         self.basePath = basePath
@@ -39,6 +42,7 @@ public struct Configuration {
         self.timeoutInterval = timeoutInterval
         self.responseQueue = responseQueue
         self.securityClient = securityClient
+        self.loggingEnabled = loggingEnabled
         self.finalizeRequestBlock = finalizeRequestBlock
     }
 }

--- a/templates/support/OAuthConfiguration.swift.hbs
+++ b/templates/support/OAuthConfiguration.swift.hbs
@@ -1,0 +1,25 @@
+//  
+//  {{>frag/generatedBy}}
+//
+
+import Foundation
+
+public struct OAuthConfiguration {
+    var preemptiveAccessTokenRefresh: TimeInterval?
+    var retryConfiguration: RetryConfiguration?
+    var loggingEnabled: Bool
+    var accessTokenDidChange: AccessTokenHandler?
+    
+    /// Initialize a new OAuthConfiguration
+    /// - Parameters:
+    ///   - preemptiveAccessTokenRefresh: Optional time interval defining how many seconds before expiration should an automatic refresh be attempted. By default no refresh is attempted until the API rejects the token.
+    ///   - retryConfiguration: A configuration for retrying requests
+    ///   - loggingEnabled: A flag to enable or disable logging
+    ///   - accessTokenDidChange: A closure to be executed when the access token changes. Defaults to `nil`.
+    public init(preemptiveAccessTokenRefresh: TimeInterval? = nil, retryConfiguration: RetryConfiguration? = nil, loggingEnabled: Bool = false, accessTokenDidChangeHandler accessTokenDidChange: AccessTokenHandler? = nil) {
+        self.preemptiveAccessTokenRefresh = preemptiveAccessTokenRefresh
+        self.retryConfiguration = retryConfiguration
+        self.accessTokenDidChange = accessTokenDidChange
+        self.loggingEnabled = loggingEnabled
+    }
+}


### PR DESCRIPTION
Dropped support for older OS versions because OSLog is now required. 
Dropping the version keeps the API code reasonably tidy as we can keep the logging on one line rather than spread over several.
Introduced an OAuthConfiguration struct to reduce the number of parameters that exist in the constructors of all of the oauth files.