### PR TITLE
OneOf entity unwrapping into Required Types

### DIFF
--- a/.changeset/dull-fireants-sneeze.md
+++ b/.changeset/dull-fireants-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@openapi-generator-plus/swift-client-generator": patch
+---
+
+Added helper Required types which filter out Unknown cases from API responses

--- a/src/index.ts
+++ b/src/index.ts
@@ -86,7 +86,7 @@ const RESERVED_WORDS = [
 	'protocol', 'public', 'repeat', 'required', 'rethrows', 'return', 'right', 'self', 'set', 'static', 'struct', 'subscript', 'super', 'switch', 'throw', 'throws', 'true',
 	'try', 'typealias', 'unowned', 'var', 'weak', 'where', 'while', 'willSet',
 	'LocalDate', 'LocalTime', 'OffsetDateTime', 'Decimal', 'String', 'Void', 'File', 'FormData',
-	'unknown', // for our enum cases
+	'unknown', "Required", // for our enum cases
 	'RetryConfiguration', 'Configuration',
 	'SecurityClient', 'SecurityClientController', 'SecurityScheme', 'OAuthPasswordFlowClient', 'OAuthClientCredentialsFlowClient', 'OAuthAuthorizationCodeFlowClient', 
 	'OAuthAccessTokenManager', 'AccessTokenHandler', 'OAuthAccessToken', 'BasicAuthenticationSecurityClient', 'APIKeySecurityClient', 'AbstractOAuthFlowClient',

--- a/templates/frag/oneOf.hbs
+++ b/templates/frag/oneOf.hbs
@@ -91,8 +91,10 @@ public enum {{{name}}}: Swift.Codable, Swift.Hashable {
 {{#ifdef interface }}
 
 public extension Sequence where Element == {{{name}}} {
-    var knownEntities: [any {{{interface.nativeType}}}] {
+    public var compactMap{{{interface.name}}}: [any {{{interface.nativeType}}}] {
         self.compactMap { $0.entity }
     }
 }
 {{/ifdef}}
+
+{{>frag/oneOfRequired}}

--- a/templates/frag/oneOf.hbs
+++ b/templates/frag/oneOf.hbs
@@ -86,6 +86,13 @@ public enum {{{name}}}: Swift.Codable, Swift.Hashable {
 {{/if}}
 {{/if}}
     }
-
     {{>frag/nestedSchemas}}
 }
+{{#ifdef interface }}
+
+public extension Sequence where Element == {{{name}}} {
+    var knownEntities: [any {{{interface.nativeType}}}] {
+        self.compactMap { $0.entity }
+    }
+}
+{{/ifdef}}

--- a/templates/frag/oneOf.hbs
+++ b/templates/frag/oneOf.hbs
@@ -91,7 +91,7 @@ public enum {{{name}}}: Swift.Codable, Swift.Hashable {
 {{#ifdef interface }}
 
 public extension Sequence where Element == {{{name}}} {
-    public var compactMap{{{interface.name}}}: [any {{{interface.nativeType}}}] {
+    public func compactMap{{{interface.name}}}() -> [any {{{interface.nativeType}}}] {
         self.compactMap { $0.entity }
     }
 }

--- a/templates/frag/oneOf.hbs
+++ b/templates/frag/oneOf.hbs
@@ -8,6 +8,17 @@ public enum {{{name}}}: Swift.Codable, Swift.Hashable {
 {{else}}
     case unknown
 {{/if}}
+{{#ifdef interface }}
+
+    var entity: (any {{{interface.nativeType}}})? {
+        switch self {
+{{#each composes}}
+        case let .{{{camelCase name}}}(entity): return entity
+{{/each}}
+        case .unknown: return nil
+        }
+    }
+{{/ifdef}}
 
     enum EncoderError: Error {
 {{#if discriminator}}

--- a/templates/frag/oneOf.hbs
+++ b/templates/frag/oneOf.hbs
@@ -10,7 +10,7 @@ public enum {{{name}}}: Swift.Codable, Swift.Hashable {
 {{/if}}
 {{#ifdef interface }}
 
-    var entity: (any {{{interface.nativeType}}})? {
+    public var entity: (any {{{interface.nativeType}}})? {
         switch self {
 {{#each composes}}
         case let .{{{camelCase name}}}(entity): return entity

--- a/templates/frag/oneOfRequired.hbs
+++ b/templates/frag/oneOfRequired.hbs
@@ -38,20 +38,20 @@ extension {{{name}}} {
 }
 
 public extension Sequence where Element == {{{name}}} {
-    public var compactMapRequired: [{{{name}}}.Required] {
+    public func compactMapRequired() -> [{{{name}}}.Required] {
         self.compactMap { .init($0) }
     }
 }
 
 public extension Sequence where Element == {{{name}}}.Required {
-    public var map{{{name}}}: [{{{name}}}] {
+    public func map{{{name}}}() -> [{{{name}}}] {
         self.map { .init($0) }
     }
 }
 {{#ifdef interface }}
 
 public extension Sequence where Element == {{{name}}}.Required {
-    public var map{{{interface.name}}}: [any {{{interface.nativeType}}}] {
+    public func map{{{interface.name}}}() -> [any {{{interface.nativeType}}}] {
         self.map { $0.entity }
     }
 }

--- a/templates/frag/oneOfRequired.hbs
+++ b/templates/frag/oneOfRequired.hbs
@@ -1,0 +1,59 @@
+{{>frag/schemaDocumentation}}
+extension {{{name}}} {
+
+    /// A convenience helper type for the `{{{name}}}` schema.
+    /// `{{{name}}}.Required` can be used to filter out the unknown case for cleaner logic on the client side.
+    public enum Required: Swift.Codable, Swift.Hashable {
+    {{#each composes}}
+        case {{{camelCase name}}}(_ value: {{{nativeType}}})
+    {{/each}}
+    {{#ifdef interface }}
+
+        public var entity: any {{{interface.nativeType}}} {
+            switch self {
+    {{#each composes}}
+            case let .{{{camelCase name}}}(entity): return entity
+    {{/each}}
+            }
+        }
+    {{/ifdef}}
+
+        public init?(_ value: {{{name}}}) {
+            switch value {
+            {{#each composes}}
+            case let .{{{camelCase name}}}(value): self = .{{{camelCase name}}}(value)
+            {{/each}}
+            case .unknown: return nil
+            }
+        }
+    }
+
+    public init(_ value: {{{name}}}.Required) {
+        switch value {
+        {{#each composes}}
+        case let .{{{camelCase name}}}(value): self = .{{{camelCase name}}}(value)
+        {{/each}}
+        }
+    }
+}
+
+public extension Sequence where Element == {{{name}}} {
+    public var compactMapRequired: [{{{name}}}.Required] {
+        self.compactMap { .init($0) }
+    }
+}
+
+public extension Sequence where Element == {{{name}}}.Required {
+    public var map{{{name}}}: [{{{name}}}] {
+        self.map { .init($0) }
+    }
+}
+{{#ifdef interface }}
+
+public extension Sequence where Element == {{{name}}}.Required {
+    public var map{{{interface.name}}}: [any {{{interface.nativeType}}}] {
+        self.map { $0.entity }
+    }
+}
+{{/ifdef}}
+


### PR DESCRIPTION
The purpose of this PR to also generate a type (and associated helpers) which only includes the known cases so that we can create simpler code by filtering out unknowns at the moment an API response is received.

This allows downstream consumers of lists of polymorphic types to have an option to effectively ignore unknown outputs and deal only with known concrete types.