### PR TITLE
Propagate required Sendable conformances

### DIFF
--- a/src/__tests__/common.ts
+++ b/src/__tests__/common.ts
@@ -20,6 +20,7 @@ export async function build(basePath: string): Promise<void> {
 			'swift build',
 			{
 				cwd: basePath,
+				maxBuffer: 1024 * 1024 * 32,
 			},
 			function(error, stdout, stderr) {
 				if (error) {

--- a/templates/frag/operation.hbs
+++ b/templates/frag/operation.hbs
@@ -48,7 +48,7 @@ public enum {{className name}}Result: Swift.Sendable {
 {{#if deprecated}}
 @available(*, deprecated, message: "This function is deprecated. Please refer to the provider of the API specification for further instructions.")
 {{/if}}
-public func {{{name}}}(_ __request: {{{className (concat group.name '_' name '_' 'requestable')}}}, {{#if requestBody.nativeType}}{{{requestBody.name}}}: {{{requestBody.nativeType}}}{{#unless requestBody.required}} = nil{{/unless}}, {{/if}}responseQueue: DispatchQueue? = nil, completion: @escaping ((_ result: Swift.Result<{{className name}}Result, Error>) -> Void)) {
+public func {{{name}}}(_ __request: {{{className (concat group.name '_' name '_' 'requestable')}}}, {{#if requestBody.nativeType}}{{{requestBody.name}}}: {{{requestBody.nativeType}}}{{#unless requestBody.required}} = nil{{/unless}}, {{/if}}responseQueue: DispatchQueue? = nil, completion: @escaping (@Sendable (_ result: Swift.Result<{{className name}}Result, Error>) -> Void)) {
     {{{name}}}({{{_requestCallParams}}}, responseQueue: responseQueue, completion: completion)
 }
 
@@ -65,7 +65,7 @@ public func {{{name}}}(_ __request: {{{className (concat group.name '_' name '_'
 {{#if deprecated}}
 @available(*, deprecated, message: "This function is deprecated. Please refer to the provider of the API specification for further instructions.")
 {{/if}}
-public func {{{name}}}({{{_params}}}{{#if _params}}, {{/if}}responseQueue: DispatchQueue? = nil, completion: @escaping ((_ result: Swift.Result<{{className name}}Result, Error>) -> Void)) {
+public func {{{name}}}({{{_params}}}{{#if _params}}, {{/if}}responseQueue: DispatchQueue? = nil, completion: @escaping (@Sendable (_ result: Swift.Result<{{className name}}Result, Error>) -> Void)) {
     let responseQueue = responseQueue ?? configuration.responseQueue
     Task {
         do {

--- a/templates/security/APIKeySecurityClient.swift.hbs
+++ b/templates/security/APIKeySecurityClient.swift.hbs
@@ -5,12 +5,12 @@
 import Foundation
 
 /// A `SecurityClient` responsible for handling API Key authentication credentials.
-public final class APIKeySecurityClient: SecurityClient, Sendable {
+public final class APIKeySecurityClient: SecurityClient, Swift.Sendable {
     
     private let apiKey: String
     private let paramName: String
     
-    public enum Mode: Sendable {
+    public enum Mode: Swift.Sendable {
         case header
         case query
         case cookie

--- a/templates/security/APIKeySecurityClient.swift.hbs
+++ b/templates/security/APIKeySecurityClient.swift.hbs
@@ -5,12 +5,12 @@
 import Foundation
 
 /// A `SecurityClient` responsible for handling API Key authentication credentials.
-public class APIKeySecurityClient: SecurityClient {
+public final class APIKeySecurityClient: SecurityClient, Sendable {
     
     private let apiKey: String
     private let paramName: String
     
-    public enum Mode {
+    public enum Mode: Sendable {
         case header
         case query
         case cookie

--- a/templates/security/AbstractOAuthFlowClient.swift.hbs
+++ b/templates/security/AbstractOAuthFlowClient.swift.hbs
@@ -4,7 +4,7 @@
 
 import Foundation
 
-public class AbstractOAuthFlowClient: SecurityClient, @unchecked Swift.Sendable {
+public class AbstractOAuthFlowClient: SecurityClient, Swift.Sendable {
     
     let tokenManager: OAuthAccessTokenManager
     

--- a/templates/security/AbstractOAuthFlowClient.swift.hbs
+++ b/templates/security/AbstractOAuthFlowClient.swift.hbs
@@ -4,7 +4,7 @@
 
 import Foundation
 
-public class AbstractOAuthFlowClient: SecurityClient {
+public class AbstractOAuthFlowClient: SecurityClient, @unchecked Sendable {
     
     let tokenManager: OAuthAccessTokenManager
     
@@ -14,13 +14,13 @@ public class AbstractOAuthFlowClient: SecurityClient {
     let configuration: OAuthConfiguration
     
     public var refreshToken: String? {
-         get async {
+        get async {
             return await tokenManager.accessToken?.refreshToken
         }
     }
 
     public var accessToken: OAuthAccessToken? {
-         get async {
+        get async {
             return await tokenManager.accessToken
         }
     }

--- a/templates/security/AbstractOAuthFlowClient.swift.hbs
+++ b/templates/security/AbstractOAuthFlowClient.swift.hbs
@@ -61,15 +61,11 @@ public class AbstractOAuthFlowClient: SecurityClient, Swift.Sendable {
     }
 }
 
-/**
- Creates a URLRequest for OAuth authentication.
-
- - Parameters:
-    - url: The URL for the request.
-    - params: A dictionary of key-value pairs for the request parameters.
-
- - Returns: A URLRequest configured for OAuth authentication.
- */
+/// Creates a URLRequest for OAuth authentication.
+/// - Parameters:
+///   - url: The URL for the request.
+///   - params: A dictionary of key-value pairs for the request parameters.
+/// - Returns: A URLRequest configured for OAuth authentication.
 func createOAuthRequest(url: URL, params: [String: String]) -> URLRequest {
     var refreshRequest = URLRequest(url: url)
     refreshRequest.httpMethod = "POST"

--- a/templates/security/AbstractOAuthFlowClient.swift.hbs
+++ b/templates/security/AbstractOAuthFlowClient.swift.hbs
@@ -10,7 +10,7 @@ public class AbstractOAuthFlowClient: SecurityClient, Swift.Sendable {
     
     let clientId: String
     let clientSecret: String
-    public var revocationURL: URL?
+    let revocationURL: URL?
     let configuration: OAuthConfiguration
     
     public var refreshToken: String? {
@@ -25,10 +25,11 @@ public class AbstractOAuthFlowClient: SecurityClient, Swift.Sendable {
         }
     }
 
-    init(clientId: String, clientSecret: String, token: OAuthAccessToken?, refreshURL: URL?, configuration: OAuthConfiguration = OAuthConfiguration()) {
+    init(clientId: String, clientSecret: String, token: OAuthAccessToken?, refreshURL: URL?, revocationURL: URL?, configuration: OAuthConfiguration = OAuthConfiguration()) {
         self.clientId = clientId
         self.clientSecret = clientSecret
         self.configuration = configuration
+        self.revocationURL = revocationURL
         self.tokenManager = OAuthAccessTokenManager(clientId: clientId, clientSecret: clientSecret, token: token, refreshTokenURL: refreshURL, configuration: configuration)
     }
     

--- a/templates/security/AbstractOAuthFlowClient.swift.hbs
+++ b/templates/security/AbstractOAuthFlowClient.swift.hbs
@@ -4,7 +4,7 @@
 
 import Foundation
 
-public class AbstractOAuthFlowClient: SecurityClient, @unchecked Sendable {
+public class AbstractOAuthFlowClient: SecurityClient, @unchecked Swift.Sendable {
     
     let tokenManager: OAuthAccessTokenManager
     

--- a/templates/security/BasicAuthenticationSecurityClient.swift.hbs
+++ b/templates/security/BasicAuthenticationSecurityClient.swift.hbs
@@ -6,7 +6,7 @@
 import Foundation
 
 /// A `SecurityClient` responsible for handling Basic authentication credentials.
-public class BasicAuthenticationSecurityClient: SecurityClient {
+public final class BasicAuthenticationSecurityClient: SecurityClient, Sendable {
     
     private let username: String
     private let password: String

--- a/templates/security/BasicAuthenticationSecurityClient.swift.hbs
+++ b/templates/security/BasicAuthenticationSecurityClient.swift.hbs
@@ -6,7 +6,7 @@
 import Foundation
 
 /// A `SecurityClient` responsible for handling Basic authentication credentials.
-public final class BasicAuthenticationSecurityClient: SecurityClient, Sendable {
+public final class BasicAuthenticationSecurityClient: SecurityClient, Swift.Sendable {
     
     private let username: String
     private let password: String

--- a/templates/security/OAuthAccessTokenManager.swift.hbs
+++ b/templates/security/OAuthAccessTokenManager.swift.hbs
@@ -10,7 +10,7 @@
 import Foundation
 {{>frag/logHeader category='oauth'}}
 
-public typealias AccessTokenHandler = (_ accessToken: OAuthAccessToken?) -> ()
+public typealias AccessTokenHandler = @Sendable (_ accessToken: OAuthAccessToken?) -> ()
 
 /** An OAuth access token manager that manages using and refreshing the access token, including handling concurrent requests and refreshes. */
 actor OAuthAccessTokenManager {

--- a/templates/security/OAuthAuthorizationCodeFlowClient.swift.hbs
+++ b/templates/security/OAuthAuthorizationCodeFlowClient.swift.hbs
@@ -10,17 +10,19 @@ public final class OAuthAuthorizationCodeFlowClient: AbstractOAuthFlowClient, Sw
     private let tokenURL: URL
     private let authorizationURL: URL
     
-    public init(clientId: String,
-                clientSecret: String,
-                token: OAuthAccessToken? = nil,
-                refreshURL: URL? = nil,
-                tokenURL: URL,
-                authorizationURL: URL,
-                configuration: OAuthConfiguration = OAuthConfiguration()) {
+    public init(
+        clientId: String,
+        clientSecret: String,
+        token: OAuthAccessToken? = nil,
+        refreshURL: URL? = nil,
+        revocationURL: URL? = nil,
+        tokenURL: URL,
+        authorizationURL: URL,
+        configuration: OAuthConfiguration = OAuthConfiguration()
+    ) {
         self.tokenURL = tokenURL
         self.authorizationURL = authorizationURL
-        
-        super.init(clientId: clientId, clientSecret: clientSecret, token: token, refreshURL: refreshURL, configuration: configuration)
+        super.init(clientId: clientId, clientSecret: clientSecret, token: token, refreshURL: refreshURL, revocationURL: revocationURL, configuration: configuration)
     }
 
     // TODO: Implement the authorization code client

--- a/templates/security/OAuthAuthorizationCodeFlowClient.swift.hbs
+++ b/templates/security/OAuthAuthorizationCodeFlowClient.swift.hbs
@@ -5,7 +5,7 @@
 import Foundation
 
 /// A client for the OAuth 2.0 Authorization Code Flow
-public class OAuthAuthorizationCodeFlowClient: AbstractOAuthFlowClient {
+public final class OAuthAuthorizationCodeFlowClient: AbstractOAuthFlowClient, Swift.Sendable {
     
     private let tokenURL: URL
     private let authorizationURL: URL

--- a/templates/security/OAuthClientCredentialsFlowClient.swift.hbs
+++ b/templates/security/OAuthClientCredentialsFlowClient.swift.hbs
@@ -9,14 +9,23 @@ public final class OAuthClientCredentialsFlowClient: AbstractOAuthFlowClient, Sw
     
     private let authenticator: Authenticator
     
-    public init(clientId: String,
-                clientSecret: String,
-                token: OAuthAccessToken? = nil,
-                refreshURL: URL? = nil,
-                tokenURL: URL,
-                configuration: OAuthConfiguration = OAuthConfiguration()) {
-        self.authenticator = Authenticator(tokenURL: tokenURL, configuration:configuration)
-        super.init(clientId: clientId, clientSecret: clientSecret, token: token, refreshURL: refreshURL, configuration: configuration)
+    public init(
+        clientId: String,
+        clientSecret: String,
+        token: OAuthAccessToken? = nil,
+        refreshURL: URL? = nil,
+        tokenURL: URL,
+        configuration: OAuthConfiguration = OAuthConfiguration()
+    ) {
+        self.authenticator = Authenticator(tokenURL: tokenURL, configuration: configuration)
+        super.init(
+            clientId: clientId, 
+            clientSecret: clientSecret, 
+            token: token, 
+            refreshURL: refreshURL, 
+            revocationURL: nil,
+            configuration: configuration
+        )
     }
     
     /// Authenticate the security client, requesting the given scopes.

--- a/templates/security/OAuthClientCredentialsFlowClient.swift.hbs
+++ b/templates/security/OAuthClientCredentialsFlowClient.swift.hbs
@@ -5,7 +5,7 @@
 import Foundation
 
 /// A client for the OAuth 2.0 Client Credentials Flow
-public class OAuthClientCredentialsFlowClient: AbstractOAuthFlowClient {
+public final class OAuthClientCredentialsFlowClient: AbstractOAuthFlowClient, Swift.Sendable {
     
     private let authenticator: Authenticator
     

--- a/templates/security/OAuthPasswordFlowClient.swift.hbs
+++ b/templates/security/OAuthPasswordFlowClient.swift.hbs
@@ -9,14 +9,17 @@ public final class OAuthPasswordFlowClient: AbstractOAuthFlowClient, Swift.Senda
     
     public private(set) var tokenURL: URL
     
-    public init(clientId: String,
-                clientSecret: String,
-                token: OAuthAccessToken? = nil,
-                refreshURL: URL? = nil,
-                tokenURL: URL,
-                configuration: OAuthConfiguration = OAuthConfiguration()) {
+    public init(
+        clientId: String,
+        clientSecret: String,
+        token: OAuthAccessToken? = nil,
+        refreshURL: URL? = nil,
+        revocationURL: URL? = nil,
+        tokenURL: URL,
+        configuration: OAuthConfiguration = OAuthConfiguration()
+    ) {
         self.tokenURL = tokenURL
-        super.init(clientId: clientId, clientSecret: clientSecret, token: token, refreshURL: refreshURL, configuration: configuration)
+        super.init(clientId: clientId, clientSecret: clientSecret, token: token, refreshURL: refreshURL, revocationURL: revocationURL, configuration: configuration)
     }
     
     /// Authenticate the security client using username and password credentials, requesting the given scopes.

--- a/templates/security/OAuthPasswordFlowClient.swift.hbs
+++ b/templates/security/OAuthPasswordFlowClient.swift.hbs
@@ -5,7 +5,7 @@
 import Foundation
 
 /// A client for the OAuth 2.0 Password Flow
-public class OAuthPasswordFlowClient: AbstractOAuthFlowClient {
+public final class OAuthPasswordFlowClient: AbstractOAuthFlowClient, Swift.Sendable {
     
     public private(set) var tokenURL: URL
     

--- a/templates/security/SecurityClient.swift.hbs
+++ b/templates/security/SecurityClient.swift.hbs
@@ -7,7 +7,7 @@ import Foundation
 /**
  A protocol defining methods for handling security within API requests.
  */
-public protocol SecurityClient {
+public protocol SecurityClient: Swift.Sendable {
     /**
      Handles reauthentication when an API request receives a 401 response.
 

--- a/templates/security/SecurityClientController.swift.hbs
+++ b/templates/security/SecurityClientController.swift.hbs
@@ -11,19 +11,19 @@ import Foundation
 
  - Note: Specific `SecurityClient` objects can be inserted or replaced dynamically to accommodate user behavior changes, such as signing in or signing out.
 */
-public class SecurityClientController: SecurityClient {
+public actor SecurityClientController: SecurityClient {
 
-    var clients: [SecurityScheme: SecurityClient] = [:]
+    var clients: [SecurityScheme: any SecurityClient] = [:]
 
-    public init(clients: [SecurityScheme : SecurityClient] = [:]) {
+    public init(clients: [SecurityScheme : any SecurityClient] = [:]) {
         self.clients = clients
     }
 
-    public func setClient(securityScheme: SecurityScheme, client: SecurityClient) {
+    public func setClient(securityScheme: SecurityScheme, client: any SecurityClient) {
         self.clients[securityScheme] = client
     }
 
-    public func getClient(securityScheme: SecurityScheme) -> SecurityClient? {
+    public func getClient(securityScheme: SecurityScheme) -> (any SecurityClient)? {
         return clients[securityScheme]
     }
 

--- a/templates/security/SecurityClientController.swift.hbs
+++ b/templates/security/SecurityClientController.swift.hbs
@@ -13,7 +13,7 @@ import Foundation
 */
 public actor SecurityClientController: SecurityClient {
 
-    var clients: [SecurityScheme: any SecurityClient] = [:]
+    private var clients: [SecurityScheme: any SecurityClient] = [:]
 
     public init(clients: [SecurityScheme : any SecurityClient] = [:]) {
         self.clients = clients

--- a/templates/security/SecurityScheme.swift.hbs
+++ b/templates/security/SecurityScheme.swift.hbs
@@ -7,7 +7,7 @@
 import Foundation
 
 /// The security schemes documented in the API specification.
-public enum SecurityScheme: String, CustomDebugStringConvertible {
+public enum SecurityScheme: String, CustomDebugStringConvertible, Swift.Sendable {
 {{#if securitySchemes}}
 {{#each securitySchemes}}
     case {{identifier name}} = {{{stringLiteral name}}}

--- a/templates/security/SecurityScheme.swift.hbs
+++ b/templates/security/SecurityScheme.swift.hbs
@@ -37,8 +37,8 @@ extension OAuthPasswordFlowClient {
         - preemptiveAccessTokenRefresh: Optional time interval defining how many seconds before expiration should an automatic refresh be attempted. By default no refresh is attempted until the API rejects the token.
         - accessTokenDidChange: A closure to be executed when the access token changes. Defaults to `nil`.
     */
-    public static func {{identifier ../name}}Client(clientId: String, clientSecret: String, token: OAuthAccessToken? = nil, configuration: OAuthConfiguration = OAuthConfiguration()) -> OAuthPasswordFlowClient {
-        OAuthPasswordFlowClient(clientId: clientId, clientSecret: clientSecret{{#if refreshUrl}}, token: token, refreshURL: URL(string: "{{{refreshUrl}}}"){{/if}}, tokenURL: URL(string: "{{{tokenUrl}}}")!, configuration: configuration)
+    public static func {{identifier ../name}}Client(clientId: String, clientSecret: String, token: OAuthAccessToken? = nil, revocationURL: URL? = nil, configuration: OAuthConfiguration = OAuthConfiguration()) -> OAuthPasswordFlowClient {
+        OAuthPasswordFlowClient(clientId: clientId, clientSecret: clientSecret{{#if refreshUrl}}, token: token, refreshURL: URL(string: "{{{refreshUrl}}}"){{/if}}, revocationURL: revocationURL, tokenURL: URL(string: "{{{tokenUrl}}}")!, configuration: configuration)
     }
 }
 {{/ifeq}}
@@ -70,8 +70,8 @@ extension OAuthAuthorizationCodeFlowClient {
         - preemptiveAccessTokenRefresh: Optional time interval defining how many seconds before expiration should an automatic refresh be attempted. By default no refresh is attempted until the API rejects the token.
         - accessTokenDidChange: A closure to be executed when the access token changes. Defaults to `nil`.
     */
-    public static func {{identifier ../name}}Client(clientId: String, clientSecret: String, token: OAuthAccessToken?, configuration: OAuthConfiguration = OAuthConfiguration()) -> OAuthAuthorizationCodeFlowClient {
-        OAuthAuthorizationCodeFlowClient(clientId: clientId, clientSecret: clientSecret{{#if refreshUrl}}, token: token, refreshURL: URL(string: "{{{refreshUrl}}}"){{/if}}, tokenURL: URL(string: "{{{tokenUrl}}}")!, authorizationURL: URL(string: "{{{authorizationUrl}}}")!, configuration: configuration)
+    public static func {{identifier ../name}}Client(clientId: String, clientSecret: String, token: OAuthAccessToken?, revocationURL: URL? = nil, configuration: OAuthConfiguration = OAuthConfiguration()) -> OAuthAuthorizationCodeFlowClient {
+        OAuthAuthorizationCodeFlowClient(clientId: clientId, clientSecret: clientSecret{{#if refreshUrl}}, token: token, refreshURL: URL(string: "{{{refreshUrl}}}"){{/if}}, revocationURL: revocationURL, tokenURL: URL(string: "{{{tokenUrl}}}")!, authorizationURL: URL(string: "{{{authorizationUrl}}}")!, configuration: configuration)
     }
 }
 {{/if}}

--- a/templates/security/SecurityScheme.swift.hbs
+++ b/templates/security/SecurityScheme.swift.hbs
@@ -28,15 +28,14 @@ public enum SecurityScheme: String, CustomDebugStringConvertible, Swift.Sendable
 {{#if tokenUrl}}
 {{#ifeq type 'password'}}
 extension OAuthPasswordFlowClient {
-    /**
-    Create an instance of `OAuthPasswordFlowClient` with provided authentication credentials, using endpoint URLs from the API specification.
-
-    - Parameters:
-        - clientId: The client ID associated with the API.
-        - clientSecret: The client secret associated with the API.
-        - preemptiveAccessTokenRefresh: Optional time interval defining how many seconds before expiration should an automatic refresh be attempted. By default no refresh is attempted until the API rejects the token.
-        - accessTokenDidChange: A closure to be executed when the access token changes. Defaults to `nil`.
-    */
+    /// Create an instance of `OAuthPasswordFlowClient` with provided authentication credentials, using endpoint URLs from the API specification.
+    /// - Parameters:
+    ///   - clientId: The client ID associated with the API.
+    ///   - clientSecret: The client secret associated with the API.
+    ///   - token: An optional `OAuthAccessToken` to initialize the client with. If not provided, the client will need to authenticate before making authorized requests.
+    ///   - revocationURL: An optional URL for revoking the access token. If not provided, the client will not be able to revoke tokens.
+    ///   - configuration: An optional `OAuthConfiguration` to customize the client's behavior. Defaults to a new instance of `OAuthConfiguration`.
+    /// - Returns: An instance of `OAuthPasswordFlowClient` initialized with the provided parameters.
     public static func {{identifier ../name}}Client(clientId: String, clientSecret: String, token: OAuthAccessToken? = nil, revocationURL: URL? = nil, configuration: OAuthConfiguration = OAuthConfiguration()) -> OAuthPasswordFlowClient {
         OAuthPasswordFlowClient(clientId: clientId, clientSecret: clientSecret{{#if refreshUrl}}, token: token, refreshURL: URL(string: "{{{refreshUrl}}}"){{/if}}, revocationURL: revocationURL, tokenURL: URL(string: "{{{tokenUrl}}}")!, configuration: configuration)
     }
@@ -44,15 +43,13 @@ extension OAuthPasswordFlowClient {
 {{/ifeq}}
 {{#ifeq type 'clientCredentials'}}
 extension OAuthClientCredentialsFlowClient {
-    /**
-    Create an instance of `OAuthClientCredentialsFlowClient` with provided authentication credentials, using endpoint URLs from the API specification.
-
-    - Parameters:
-        - clientId: The client ID associated with the API.
-        - clientSecret: The client secret associated with the API.
-        - preemptiveAccessTokenRefresh: Optional time interval defining how many seconds before expiration should an automatic refresh be attempted. By default no refresh is attempted until the API rejects the token.
-        - accessTokenDidChange: A closure to be executed when the access token changes. Defaults to `nil`.
-    */
+    /// Create an instance of `OAuthClientCredentialsFlowClient` with provided authentication credentials, using endpoint URLs from the API specification.
+    /// - Parameters:
+    ///   - clientId: The client ID associated with the API.
+    ///   - clientSecret: The client secret associated with the API.
+    ///   - token: An optional `OAuthAccessToken` to initialize the client with.
+    ///   - configuration: An optional `OAuthConfiguration` to customize the client's behavior. Defaults to a new instance of `OAuthConfiguration`.
+    /// - Returns: An instance of `OAuthClientCredentialsFlowClient` initialized with the provided parameters.
     public static func {{identifier ../name}}Client(clientId: String, clientSecret: String, token: OAuthAccessToken? = nil, configuration: OAuthConfiguration = OAuthConfiguration()) -> OAuthClientCredentialsFlowClient {
         OAuthClientCredentialsFlowClient(clientId: clientId, clientSecret: clientSecret{{#if refreshUrl}}, token: token, refreshURL: URL(string: "{{{refreshUrl}}}"){{/if}}, tokenURL: URL(string: "{{{tokenUrl}}}")!, configuration: configuration)
     }
@@ -61,15 +58,14 @@ extension OAuthClientCredentialsFlowClient {
 {{#ifeq type 'authorizationCode'}}
 {{#if authorizationUrl}}
 extension OAuthAuthorizationCodeFlowClient {
-    /**
-    Create an instance of `OAuthAuthorizationCodeFlowClient` with provided authentication credentials, using endpoint URLs from the API specification.
-
-    - Parameters:
-        - clientId: The client ID associated with the API.
-        - clientSecret: The client secret associated with the API.
-        - preemptiveAccessTokenRefresh: Optional time interval defining how many seconds before expiration should an automatic refresh be attempted. By default no refresh is attempted until the API rejects the token.
-        - accessTokenDidChange: A closure to be executed when the access token changes. Defaults to `nil`.
-    */
+    /// Create an instance of `OAuthAuthorizationCodeFlowClient` with provided authentication credentials, using endpoint URLs from the API specification.
+    /// - Parameters:
+    ///   - clientId: The client ID associated with the API.
+    ///   - clientSecret: The client secret associated with the API.
+    ///   - token: An optional `OAuthAccessToken` to initialize the client with.
+    ///   - revocationURL: An optional URL for revoking the access token. If not provided, the client will not be able to revoke tokens.
+    ///   - configuration: An optional `OAuthConfiguration` to customize the client's behavior. Defaults to a new instance of `OAuthConfiguration`.
+    /// - Returns: An instance of `OAuthAuthorizationCodeFlowClient` initialized with the provided parameters.
     public static func {{identifier ../name}}Client(clientId: String, clientSecret: String, token: OAuthAccessToken?, revocationURL: URL? = nil, configuration: OAuthConfiguration = OAuthConfiguration()) -> OAuthAuthorizationCodeFlowClient {
         OAuthAuthorizationCodeFlowClient(clientId: clientId, clientSecret: clientSecret{{#if refreshUrl}}, token: token, refreshURL: URL(string: "{{{refreshUrl}}}"){{/if}}, revocationURL: revocationURL, tokenURL: URL(string: "{{{tokenUrl}}}")!, authorizationURL: URL(string: "{{{authorizationUrl}}}")!, configuration: configuration)
     }

--- a/templates/support/Configuration.swift.hbs
+++ b/templates/support/Configuration.swift.hbs
@@ -4,7 +4,7 @@
 
 import Foundation
 
-public typealias ConfigurationFinalizeRequestBlock = ((_ request: inout Foundation.URLRequest) -> Void)
+public typealias ConfigurationFinalizeRequestBlock = @Sendable (_ request: inout Foundation.URLRequest) -> Void
 
 public struct Configuration: Swift.Sendable {
 

--- a/templates/support/URLSession+Api.swift.hbs
+++ b/templates/support/URLSession+Api.swift.hbs
@@ -9,7 +9,7 @@ extension Foundation.URLSession {
     static var apiSession = Foundation.URLSession(configuration: .default)
 
     @available(*, renamed: "handleApiRequest(_:)")
-    static func handleApiRequest(_ request: Foundation.URLRequest, retryConfiguration: RetryConfiguration?, completion: @escaping ((_ response: Foundation.HTTPURLResponse?, _ data: Data?, _ error: Error?) -> Void)) {
+    static func handleApiRequest(_ request: Foundation.URLRequest, retryConfiguration: RetryConfiguration?, completion: @escaping @Sendable (_ response: Foundation.HTTPURLResponse?, _ data: Data?, _ error: Error?) -> Void) {
         Task {
             do {
                 let result = try await handleApiRequest(request, retryConfiguration: retryConfiguration)

--- a/templates/support/URLSession+Api.swift.hbs
+++ b/templates/support/URLSession+Api.swift.hbs
@@ -6,7 +6,7 @@ import Foundation
 
 extension Foundation.URLSession {
 
-    static var apiSession = Foundation.URLSession(configuration: .default)
+    static let apiSession = Foundation.URLSession(configuration: .default)
 
     @available(*, renamed: "handleApiRequest(_:)")
     static func handleApiRequest(_ request: Foundation.URLRequest, retryConfiguration: RetryConfiguration?, completion: @escaping @Sendable (_ response: Foundation.HTTPURLResponse?, _ data: Data?, _ error: Error?) -> Void) {

--- a/templates/support/URLSession+Api.swift.hbs
+++ b/templates/support/URLSession+Api.swift.hbs
@@ -6,7 +6,7 @@ import Foundation
 
 extension Foundation.URLSession {
 
-    static let apiSession = Foundation.URLSession(configuration: .default)
+    private static let apiSession = Foundation.URLSession(configuration: .default)
 
     @available(*, renamed: "handleApiRequest(_:)")
     static func handleApiRequest(_ request: Foundation.URLRequest, retryConfiguration: RetryConfiguration?, completion: @escaping @Sendable (_ response: Foundation.HTTPURLResponse?, _ data: Data?, _ error: Error?) -> Void) {


### PR DESCRIPTION
# Description
After the latest addition of Sendable conformance to different models in the generator, the project now fails `swift build` because additional closures and models are not marked as Sendable. 

This PR propagates Sendable conformance to those locations that needs Sendable conformance. 

One exception to a simple conformance-to-Sendable is SecurityClientController. This class was rather refactored to an actor, which will ensure race condition safety better by serialising the access to the controllers array. And as actors are inherently Sendable, the sendable constraint from `SecurityClient` is resolved as well.

`swift build` passes on all test cases after making these changes. 

In addition, max buffer size in test build was increased to a custom value of 32MB, as on certain large API yamls, the test cases were failing due to the number of warnings it produced, rather than the error it contains.