### PR TITLE
Force Swift 6 build mode and enforce immutability on OAuthPasswordFlowClient

### DIFF
--- a/.changeset/many-numbers-carry.md
+++ b/.changeset/many-numbers-carry.md
@@ -2,4 +2,4 @@
 "@openapi-generator-plus/swift-client-generator": minor
 ---
 
-Upgrade to Swift 6 on swift builds for tests
+Prepare for Swift 6 by ensuring immutability on OAuthPasswordFlowClient and Swift 6 build on testing.

--- a/.changeset/many-numbers-carry.md
+++ b/.changeset/many-numbers-carry.md
@@ -1,0 +1,5 @@
+---
+"@openapi-generator-plus/swift-client-generator": minor
+---
+
+Upgrade to Swift 6 on swift builds for tests

--- a/src/__tests__/common.ts
+++ b/src/__tests__/common.ts
@@ -17,7 +17,7 @@ export async function prepare(spec: string, config?: CodegenConfig): Promise<Cod
 export async function build(basePath: string): Promise<void> {
 	return new Promise(function(resolve, reject) {
 		exec(
-			'swift build',
+			'swift build -Xswiftc "-swift-version" -Xswiftc "6"',
 			{
 				cwd: basePath,
 				maxBuffer: 1024 * 1024 * 32,

--- a/templates/security/OAuthPasswordFlowClient.swift.hbs
+++ b/templates/security/OAuthPasswordFlowClient.swift.hbs
@@ -7,7 +7,7 @@ import Foundation
 /// A client for the OAuth 2.0 Password Flow
 public final class OAuthPasswordFlowClient: AbstractOAuthFlowClient, Swift.Sendable {
     
-    public private(set) var tokenURL: URL
+    public let tokenURL: URL
     
     public init(
         clientId: String,

--- a/templates/support/DispatchQueue+Api.swift.hbs
+++ b/templates/support/DispatchQueue+Api.swift.hbs
@@ -5,7 +5,7 @@
 import Foundation
 
 extension Swift.Optional where Wrapped == Dispatch.DispatchQueue {
-    public func asyncIfPresent(group: Dispatch.DispatchGroup? = nil, qos: Dispatch.DispatchQoS = .unspecified, flags: Dispatch.DispatchWorkItemFlags = [], execute work: @escaping @convention(block) () -> Void) {
+    public func asyncIfPresent(group: Dispatch.DispatchGroup? = nil, qos: Dispatch.DispatchQoS = .unspecified, flags: Dispatch.DispatchWorkItemFlags = [], execute work: @Sendable @escaping @convention(block) () -> Void) {
         if let q = self {
             q.async(group: group, qos: qos, flags: flags, execute: work)
         } else {


### PR DESCRIPTION
# Description
This pull request upgrades the Swift client generator to support Swift 6 and makes several improvements to concurrency safety and code clarity in the generated Swift code and test harnesses. The most important changes are grouped below:

**Swift 6 Upgrade:**

* Updated test builds to use Swift 6 by adding the appropriate flags to the `swift build` command in `common.ts`.
* Documented the upgrade to Swift 6 in the changeset for the `@openapi-generator-plus/swift-client-generator` package.

**Concurrency and API Improvements in Generated Swift Code:**

* Changed the `tokenURL` property in `OAuthPasswordFlowClient` from `private(set) var` to `let` for immutability and clarity.
* Added the `@Sendable` attribute to the closure parameter in the `asyncIfPresent` extension for `DispatchQueue?`, improving concurrency safety.