### PR TITLE
Make AbstractOAuthFlowClient unchecked sendable

### DIFF
--- a/templates/security/AbstractOAuthFlowClient.swift.hbs
+++ b/templates/security/AbstractOAuthFlowClient.swift.hbs
@@ -4,7 +4,7 @@
 
 import Foundation
 
-public class AbstractOAuthFlowClient: SecurityClient, Swift.Sendable {
+public class AbstractOAuthFlowClient: SecurityClient, @unchecked Swift.Sendable {
     
     let tokenManager: OAuthAccessTokenManager
     


### PR DESCRIPTION
# Description

This pull request fixes the compile-time error caused by non-final class 'AbstractOAuthFlowClient' conforming to 'Sendable'. Swift in Swift 6 language mode, forces non-final classes that cannot be fully checked of its Sendability to conform to Sendable with `@unchecked Sendable`. AbstractOAuthFlowClient is a non-final class that should still be guaranteed of its sendability. Practically, it is only overridden by classes which are explicitly Sendable and checked to be Sendable, but given the use of this type in concurrent context, this class also needs to be guaranteed of Sendability using `@unchecked Sendable` annotation.