### PR TITLE
feature: Adds an on APIError closure in configuration

### DIFF
--- a/.changeset/spicy-canyons-taste.md
+++ b/.changeset/spicy-canyons-taste.md
@@ -1,0 +1,5 @@
+---
+"@openapi-generator-plus/swift-client-generator": patch
+---
+
+Adds an on APIError closure in configuration

--- a/templates/frag/operation.hbs
+++ b/templates/frag/operation.hbs
@@ -86,7 +86,12 @@ public func {{{name}}}({{{_params}}}{{#if _params}}, {{/if}}responseQueue: Dispa
 @available(*, deprecated, message: "This function is deprecated. Please refer to the provider of the API specification for further instructions.")
 {{/if}}
 public func {{{name}}}({{{_params}}}) async throws -> {{className name}}Result {
-    return try await {{{name}}}({{{_callParams}}}{{#if _params}}, {{/if}}allowsReauth: true)
+    do {
+        return try await {{{name}}}({{{_callParams}}}{{#if _params}}, {{/if}}allowsReauth: true)
+    } catch let error as APIError {
+        configuration.onError?(error)
+        throw error
+    }
 }
 
 private func {{{name}}}({{{_params}}}{{#if _params}}, {{/if}}allowsReauth: Bool) async throws -> {{className name}}Result {

--- a/templates/support/APIError.swift.hbs
+++ b/templates/support/APIError.swift.hbs
@@ -20,4 +20,7 @@ public enum APIError: Swift.Error {
 
     /// An response was received with an undocumented status code
     case unexpectedResponse(_ response: Foundation.URLResponse, data: Foundation.Data)
+
+    /// An error thrown by URLSession. Can be `Foundation.URLError`, `Swift.CancellationError`, or something unknown.
+    case urlSessionError(_ error: Swift.Error, request: Foundation.URLRequest)
 }

--- a/templates/support/Configuration.swift.hbs
+++ b/templates/support/Configuration.swift.hbs
@@ -5,15 +5,14 @@
 import Foundation
 
 public typealias ConfigurationFinalizeRequestBlock = @Sendable (_ request: inout Foundation.URLRequest) -> Void
+public typealias OnErrorBlock = @Sendable (_ error: APIError) -> Void
 
 public struct Configuration: Swift.Sendable {
 
-    /** The handler for all security requests. */
+    /// The handler for all security requests.
     public var securityClient: SecurityClient?
 
-    /**
-     * Override the default base path.
-     */
+    /// Override the default base path.
     public var basePath: Swift.String?
 
     public var cachePolicy: Foundation.URLRequest.CachePolicy?
@@ -25,6 +24,10 @@ public struct Configuration: Swift.Sendable {
     public var finalizeRequestBlock: ConfigurationFinalizeRequestBlock?
 
     public var retryConfiguration: RetryConfiguration?
+    
+    /// A block that is called whenever an APIError is thrown. 
+    /// This can be used to log errors, or to trigger a global reauthentication flow on authentication errors.
+    public var onError: OnErrorBlock?
 
     public var loggingEnabled: Bool
 
@@ -34,6 +37,7 @@ public struct Configuration: Swift.Sendable {
         timeoutInterval: Foundation.TimeInterval = 30,
         responseQueue: Dispatch.DispatchQueue? = nil,
         securityClient: SecurityClient? = nil,
+        onError: OnErrorBlock? = nil,
         loggingEnabled: Bool = false,
         finalizeRequestBlock: ConfigurationFinalizeRequestBlock? = nil
     ) {
@@ -42,6 +46,7 @@ public struct Configuration: Swift.Sendable {
         self.timeoutInterval = timeoutInterval
         self.responseQueue = responseQueue
         self.securityClient = securityClient
+        self.onError = onError
         self.loggingEnabled = loggingEnabled
         self.finalizeRequestBlock = finalizeRequestBlock
     }

--- a/templates/support/URLSession+Api.swift.hbs
+++ b/templates/support/URLSession+Api.swift.hbs
@@ -21,7 +21,14 @@ extension Foundation.URLSession {
     }
     
     static func handleApiRequest(_ request: Foundation.URLRequest, attemptsTried: Int = 0, retryConfiguration: RetryConfiguration?) async throws -> URLSessionResponse {
-        let (data, response) = try await apiSession.data(for: request)
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await apiSession.data(for: request)
+        } catch {
+            throw APIError.urlSessionError(error, request: request)
+        }
+
         guard let httpResponse = response as? HTTPURLResponse else {
             throw APIError.unexpectedResponse(response, data: data)
         }


### PR DESCRIPTION
This provides an opportunity for the consumer to watch the errors and send them to other logging systems such as crashlytics etc.

We also remove the opportunity for this library to throw any kind of error other than our `APIError` type so that we don't have the `else` case for the unknown error type.